### PR TITLE
Fix help images not loading with BASE_PATH

### DIFF
--- a/client/web/docker-entrypoint.sh
+++ b/client/web/docker-entrypoint.sh
@@ -24,9 +24,9 @@ if [ "${BASE_PATH:-/}" != "/" ]; then
   # index.html: href="/..." and src="/..."
   sed -i "s|href=\"/|href=\"${BASE_PATH}|g; s|src=\"/|src=\"${BASE_PATH}|g" $HTML_DIR/index.html
 
-  # JS bundle: "/filename.svg" references
+  # JS bundle: "/filename.svg" and "/help/" references
   for f in $HTML_DIR/assets/*.js; do
-    sed -i "s|\"/favicon_|\"${BASE_PATH}favicon_|g; s|\"/gear\.|\"${BASE_PATH}gear.|g; s|\"/timer\.|\"${BASE_PATH}timer.|g; s|\"/logo_|\"${BASE_PATH}logo_|g; s|\"/name_|\"${BASE_PATH}name_|g" "$f"
+    sed -i "s|\"/favicon_|\"${BASE_PATH}favicon_|g; s|\"/gear\.|\"${BASE_PATH}gear.|g; s|\"/timer\.|\"${BASE_PATH}timer.|g; s|\"/logo_|\"${BASE_PATH}logo_|g; s|\"/name_|\"${BASE_PATH}name_|g; s|\"/help/|\"${BASE_PATH}help/|g" "$f"
   done
 
   # CSS bundle: url(/fonts/...) and url(/pattern_...)


### PR DESCRIPTION
## Summary
- The `docker-entrypoint.sh` sed rules for rewriting root-relative paths in the JS bundle didn't include `/help/` image paths
- When deployed under a BASE_PATH (e.g., `/beta/`), help screenshots requested `/help/...` instead of `/beta/help/...`, returning 404s

## Test plan
- [ ] Deploy with `BASE_PATH=/beta/` and verify help images load
- [ ] Verify help images still work with default BASE_PATH (`/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)