### PR TITLE
Pre-select target robot, letters-only room codes, longer disconnect grace period

### DIFF
--- a/client/web/src/components/GameBoard.vue
+++ b/client/web/src/components/GameBoard.vue
@@ -40,20 +40,11 @@ const boardRef = ref<HTMLElement | null>(null)
 // First-game onboarding
 const onboardingSeen = ref(!!localStorage.getItem('bouncebot_onboarding_seen'))
 const isFirstGame = computed(() => !onboardingSeen.value)
-const showTargetPulse = ref(!onboardingSeen.value)
 
 function dismissOnboarding() {
   localStorage.setItem('bouncebot_onboarding_seen', '1')
   onboardingSeen.value = true
 }
-
-// Stop target pulse once a robot is selected
-const stopPulseWatcher = watch(() => store.selectedRobotId, (id) => {
-  if (id !== null && showTargetPulse.value) {
-    showTargetPulse.value = false
-    stopPulseWatcher()
-  }
-})
 
 // Percentage-based sizing for responsive board
 const CELL_PERCENT = 100 / BOARD_SIZE  // 6.25%
@@ -420,7 +411,7 @@ function handleSwitchPlayerSolution(index: number) {
               v-for="robot in store.robots"
               :key="`robot-${robot.id}`"
               class="robot"
-              :class="{ selected: store.selectedRobotId === robot.id, replaying: isReplaying, 'target-pulse': showTargetPulse && robot.id === store.target.robotId && store.selectedRobotId === null }"
+              :class="{ selected: store.selectedRobotId === robot.id, replaying: isReplaying }"
               :style="getRobotStyle(robot)"
               @click="store.selectRobot(robot.id)"
             >
@@ -1139,15 +1130,6 @@ function handleSwitchPlayerSolution(index: number) {
 
 .robot:hover {
   transform: translate(-50%, -50%) scale(1.05);
-}
-
-@keyframes target-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); }
-  50% { box-shadow: 0 0 12px 8px rgba(255, 255, 255, 0.8); }
-}
-
-.robot.target-pulse {
-  animation: target-pulse 1.2s ease-in-out infinite;
 }
 
 .robot.selected {

--- a/client/web/src/stores/gameStore.ts
+++ b/client/web/src/stores/gameStore.ts
@@ -612,7 +612,7 @@ export const useGameStore = defineStore('game', () => {
       committedMoves.value = []
     }
 
-    selectedRobotId.value = null
+    selectedRobotId.value = target.value.robotId
   }
 
   // Reset board to initial robot positions (for replay)

--- a/client/web/src/views/HomeView.vue
+++ b/client/web/src/views/HomeView.vue
@@ -15,7 +15,11 @@ const featureStore = useFeatureStore()
 
 const storedName = roomStore.currentPlayerName
 const playerName = ref(storedName && storedName !== 'Player' ? storedName : '')
-const joinRoomId = ref('')
+const joinRoomIdRaw = ref('')
+const joinRoomId = computed({
+  get: () => joinRoomIdRaw.value,
+  set: (v: string) => { joinRoomIdRaw.value = v.toUpperCase() },
+})
 const isStartingSolo = ref(false)
 const isCreating = ref(false)
 const isJoining = ref(false)
@@ -261,6 +265,7 @@ async function joinRoom() {
                 v-model="joinRoomId"
                 type="text"
                 placeholder="Room ID"
+                maxlength="4"
                 class="room-id-inline"
                 :disabled="isLoading"
                 @keyup.enter="joinRoom"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -52,7 +52,7 @@ func DefaultConfig() *Config {
 		AutoSaveInterval:      30 * time.Second,
 		CleanupInterval:       1 * time.Hour,
 		RoomMaxAge:            24 * time.Hour,
-		DisconnectGracePeriod:     30 * time.Second,
+		DisconnectGracePeriod:     5 * time.Minute,
 		SoloDisconnectGracePeriod: 30 * time.Minute,
 		SolverTimeout:         30 * time.Second,
 	}
@@ -74,7 +74,7 @@ func (c *Config) RoomsFile() string {
 //   - AUTO_SAVE_INTERVAL: Auto-save interval in seconds (default: 30)
 //   - CLEANUP_INTERVAL: Cleanup interval in seconds (default: 3600)
 //   - ROOM_MAX_AGE: Room max age in seconds (default: 86400)
-//   - DISCONNECT_GRACE_PERIOD: Player disconnect grace period in seconds (default: 30)
+//   - DISCONNECT_GRACE_PERIOD: Player disconnect grace period in seconds (default: 300)
 //   - SOLO_DISCONNECT_GRACE_PERIOD: Solo mode disconnect grace period in seconds (default: 1800)
 //   - SOLVER_TIMEOUT: Solver timeout in seconds (default: 30)
 //   - ENABLE_DAILY_CHALLENGE: Enable daily challenge feature (default: false)

--- a/server/room/repository.go
+++ b/server/room/repository.go
@@ -54,8 +54,8 @@ func NewRoomRepository() RoomRepository {
 	}
 }
 
-// roomIDChars is the character set for room IDs (no 0, 1, I, O to avoid confusion)
-const roomIDChars = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+// roomIDChars is the character set for room IDs (letters only, no digits)
+const roomIDChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // generateRoomID creates a random 4-character room ID.
 func generateRoomID() string {

--- a/server/room/service.go
+++ b/server/room/service.go
@@ -42,7 +42,7 @@ func NewRoomService() *RoomService {
 		solutionMgr:           solutionMgr,
 		persistence:           NewPersistenceManager(),
 		timerMgr:              NewTimerManager(),
-		disconnectGracePeriod:     30 * time.Second,
+		disconnectGracePeriod:     5 * time.Minute,
 		soloDisconnectGracePeriod: 30 * time.Minute,
 	}
 }


### PR DESCRIPTION
## Summary
- Auto-select the target robot at game/round start so the first swipe/arrow-key move works without tapping it first; removed the now-dead onboarding pulse animation (it only showed while nothing was selected).
- Room codes now use the full A-Z alphabet instead of digits; the join-room input auto-uppercases as you type and caps at 4 characters to match.
- Bumped the multiplayer disconnect grace period from 30s to 5 minutes so briefly looking away from your phone doesn't get you booted (solo grace period unchanged at 30 min).

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] `vue-tsc --noEmit` passes
- [x] Verified in browser: target robot shows selected on game start and first arrow-key move works immediately
- [x] Verified in browser: typing a lowercase, over-length room code renders as uppercase and truncated to 4 chars
- [x] Verified `config.DefaultConfig()` returns 5m disconnect grace period

🤖 Generated with [Claude Code](https://claude.com/claude-code)