### PR TITLE
Render selected robot's highlight ring above walls

### DIFF
--- a/client/web/src/components/GameBoard.vue
+++ b/client/web/src/components/GameBoard.vue
@@ -1119,7 +1119,7 @@ function handleSwitchPlayerSolution(index: number) {
   user-select: none;
   cursor: pointer;
   transition: left 0.15s ease-out, top 0.15s ease-out, transform 0.1s, box-shadow 0.1s;
-  z-index: 2;
+  z-index: 11;
   border: 1px solid black;
   text-shadow: -0.5px -0.5px 0 black, 0.5px -0.5px 0 black, -0.5px 0.5px 0 black, 0.5px 0.5px 0 black;
 }


### PR DESCRIPTION
## Summary
- The selected robot's ring is a box-shadow, so it renders subject to the robot's own z-index. Walls (z-index 5) and the outer board edge pseudo-element (z-index 10) were both painting over it, clipping the ring flat wherever a wall or the board border was adjacent.
- Raised `.robot` to z-index 11 so it renders above both.

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] Verified in browser via before/after A/B: ring is clipped flat against interior walls and the outer board border at z-index 2, renders as a full unclipped circle at z-index 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)