### PR TITLE
Add board sharing via URL and QR code

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -12,6 +12,7 @@
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
         "pinia": "^3.0.4",
+        "qrcode": "^1.5.4",
         "vue": "^3.5.24",
         "vue-router": "^4.6.3"
       },
@@ -19,6 +20,7 @@
         "@bufbuild/buf": "^1.61.0",
         "@bufbuild/protoc-gen-es": "^2.10.1",
         "@types/node": "^24.10.1",
+        "@types/qrcode": "^1.5.6",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/tsconfig": "^0.8.1",
         "jsdom": "^27.4.0",
@@ -1299,6 +1301,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript/vfs": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.2.tgz",
@@ -1672,6 +1684,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1701,6 +1737,15 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
@@ -1710,6 +1755,35 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
@@ -1793,11 +1867,32 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -1895,6 +1990,19 @@
         }
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1908,6 +2016,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/hookable": {
@@ -1955,6 +2072,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2015,6 +2141,18 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lru-cache": {
@@ -2092,6 +2230,42 @@
       ],
       "license": "MIT"
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -2124,6 +2298,15 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2179,6 +2362,15 @@
         }
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -2217,6 +2409,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2226,6 +2444,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -2288,6 +2512,12 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2326,6 +2556,32 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/superjson": {
       "version": "2.2.6",
@@ -2726,6 +2982,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2738,6 +3000,20 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -2781,6 +3057,47 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -16,6 +16,7 @@
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
     "pinia": "^3.0.4",
+    "qrcode": "^1.5.4",
     "vue": "^3.5.24",
     "vue-router": "^4.6.3"
   },
@@ -23,6 +24,7 @@
     "@bufbuild/buf": "^1.61.0",
     "@bufbuild/protoc-gen-es": "^2.10.1",
     "@types/node": "^24.10.1",
+    "@types/qrcode": "^1.5.6",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.8.1",
     "jsdom": "^27.4.0",

--- a/client/web/src/components/GameBoard.vue
+++ b/client/web/src/components/GameBoard.vue
@@ -33,6 +33,10 @@ const props = defineProps<{
   playerColor?: string
 }>()
 
+const emit = defineEmits<{
+  share: []
+}>()
+
 const store = useGameStore()
 const showHowToPlay = ref(false)
 const boardRef = ref<HTMLElement | null>(null)
@@ -364,6 +368,11 @@ function handleSwitchPlayerSolution(index: number) {
         <h1 v-if="props.gameNumber != null" class="title">
           <span class="game-label">GAME</span>
           <span class="game-number">{{ props.gameNumber }}</span>
+          <button class="share-btn" title="Share this board" aria-label="Share this board" @click="emit('share')">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="white">
+              <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z" />
+            </svg>
+          </button>
         </h1>
         <!-- Board area (board + hints) -->
         <div class="board-area">
@@ -653,6 +662,28 @@ function handleSwitchPlayerSolution(index: number) {
   margin-top: 1rem;
   font-size: 1.8rem;
   text-align: center;
+  position: relative;
+}
+
+.share-btn {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: #1976d2;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+
+.share-btn:hover {
+  background: #1565c0;
 }
 
 .game-label {
@@ -844,6 +875,15 @@ function handleSwitchPlayerSolution(index: number) {
   .title {
     grid-column: 1;
     font-size: 1.4rem;
+    /* Match .board's width formula so the share button (right-aligned within
+       .title) lines up with the board's actual right edge, not the screen's -
+       the board is height-constrained and centered on mobile, so it's often
+       narrower than the full row width. Must be `width`, not `max-width`: a
+       grid item with auto margins and no explicit width shrinks to fit its
+       content instead of stretching, which breaks the alignment. */
+    width: min(calc(100% - 2rem), calc(100dvh - 19rem), calc(100vh - 19rem));
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .board-area {

--- a/client/web/src/components/ShareModal.vue
+++ b/client/web/src/components/ShareModal.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import QRCode from 'qrcode'
+
+const props = defineProps<{
+  show: boolean
+  url: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const qrDataUrl = ref<string | null>(null)
+const copyLabel = ref('Copy Link')
+let copyResetTimeout: ReturnType<typeof setTimeout> | null = null
+
+watch(
+  () => [props.show, props.url] as const,
+  async ([show, url]) => {
+    if (!show || !url) return
+    copyLabel.value = 'Copy Link'
+    qrDataUrl.value = await QRCode.toDataURL(url, { margin: 1, width: 240 })
+  },
+  { immediate: true }
+)
+
+function handleBackdropClick(event: MouseEvent) {
+  if (event.target === event.currentTarget) {
+    emit('close')
+  }
+}
+
+async function copyLink() {
+  try {
+    await navigator.clipboard.writeText(props.url)
+  } catch {
+    // Fallback for older browsers or when clipboard API fails
+    const textArea = document.createElement('textarea')
+    textArea.value = props.url
+    document.body.appendChild(textArea)
+    textArea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textArea)
+  }
+
+  copyLabel.value = 'Copied!'
+  if (copyResetTimeout) clearTimeout(copyResetTimeout)
+  copyResetTimeout = setTimeout(() => {
+    copyLabel.value = 'Copy Link'
+  }, 1500)
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="show" class="modal-backdrop" @click="handleBackdropClick">
+      <div class="modal share-modal">
+        <button class="close-btn" @click="emit('close')">×</button>
+        <h2>Share Board</h2>
+
+        <div class="qr-wrapper">
+          <img v-if="qrDataUrl" :src="qrDataUrl" alt="QR code for the shared board link" class="qr-image" />
+        </div>
+
+        <button class="copy-link-btn" @click="copyLink">{{ copyLabel }}</button>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #1a1a1a;
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  max-width: 400px;
+  width: 90%;
+  position: relative;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.share-modal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.close-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.close-btn:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+h2 {
+  margin: 0 0 1.25rem 0;
+  color: #43a047;
+  font-size: 1.25rem;
+}
+
+.qr-wrapper {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 240px;
+  height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.qr-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.copy-link-btn {
+  margin-top: 1.25rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: #43a047;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.copy-link-btn:hover {
+  background: #388e3c;
+}
+
+@media (prefers-color-scheme: light) {
+  .modal {
+    background: #fff;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  }
+
+  .close-btn {
+    color: #666;
+  }
+
+  .close-btn:hover {
+    color: #333;
+    background: rgba(0, 0, 0, 0.1);
+  }
+}
+</style>

--- a/client/web/src/gen/bouncebot_pb.ts
+++ b/client/web/src/gen/bouncebot_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file bouncebot.proto.
  */
 export const file_bouncebot: GenFile = /*@__PURE__*/
-  fileDesc("Cg9ib3VuY2Vib3QucHJvdG8SCWJvdW5jZWJvdCIgCghQb3NpdGlvbhIJCgF4GAEgASgFEgkKAXkYAiABKAUikAEKBUJvYXJkEgwKBHNpemUYASABKAUSJAoHdl93YWxscxgCIAMoCzITLmJvdW5jZWJvdC5Qb3NpdGlvbhIkCgdoX3dhbGxzGAMgAygLMhMuYm91bmNlYm90LlBvc2l0aW9uEi0KEHBvc3NpYmxlX3RhcmdldHMYBCADKAsyEy5ib3VuY2Vib3QuUG9zaXRpb24iNgoGQm90UG9zEgoKAmlkGAEgASgFEiAKA3BvcxgCIAEoCzITLmJvdW5jZWJvdC5Qb3NpdGlvbiJrCgRHYW1lEh8KBWJvYXJkGAEgASgLMhAuYm91bmNlYm90LkJvYXJkEh8KBGJvdHMYAiADKAsyES5ib3VuY2Vib3QuQm90UG9zEiEKBnRhcmdldBgDIAEoCzIRLmJvdW5jZWJvdC5Cb3RQb3MiNwoGUGxheWVyEgoKAmlkGAEgASgJEgwKBG5hbWUYAiABKAkSEwoLY29sb3JfaW5kZXgYAyABKAUidAoOUGxheWVyU29sdXRpb24SEQoJcGxheWVyX2lkGAEgASgJEi0KCXNvbHZlZF9hdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASIAoFbW92ZXMYAyADKAsyES5ib3VuY2Vib3QuQm90UG9zIi4KC1BsYXllclNjb3JlEhEKCXBsYXllcl9pZBgBIAEoCRIMCgR3aW5zGAIgASgFImoKDFJvb21TZXR0aW5ncxIeChZzaG93X3NvbHZlcl9tb3ZlX2NvdW50GAEgASgIEh0KFXNob3dfc29sdmVyX3NvbHV0aW9ucxgCIAEoCBIbChNtaW5fc29sdXRpb25fbGVuZ3RoGAMgASgFIoIECgRSb29tEgoKAmlkGAEgASgJEiIKB3BsYXllcnMYAiADKAsyES5ib3VuY2Vib3QuUGxheWVyEi4KCmNyZWF0ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEiUKDGN1cnJlbnRfZ2FtZRgEIAEoCzIPLmJvdW5jZWJvdC5HYW1lEjMKD2dhbWVfc3RhcnRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLAoJc29sdXRpb25zGAYgAygLMhkuYm91bmNlYm90LlBsYXllclNvbHV0aW9uEiYKBnNjb3JlcxgHIAMoCzIWLmJvdW5jZWJvdC5QbGF5ZXJTY29yZRIUCgxnYW1lc19wbGF5ZWQYCCABKAUSGAoQZmluaXNoZWRfc29sdmluZxgJIAMoCRIWCg5yZWFkeV9mb3JfbmV4dBgKIAMoCRIYChBpc19zaW5nbGVfcGxheWVyGAsgASgIEioKD3BlbmRpbmdfcGxheWVycxgMIAMoCzIRLmJvdW5jZWJvdC5QbGF5ZXISLwoOc29sdmVyX3Jlc3VsdHMYDSADKAsyFy5ib3VuY2Vib3QuU29sdmVyUmVzdWx0EikKCHNldHRpbmdzGA4gASgLMhcuYm91bmNlYm90LlJvb21TZXR0aW5ncyJCChFDcmVhdGVSb29tUmVxdWVzdBITCgtwbGF5ZXJfbmFtZRgBIAEoCRIYChBpc19zaW5nbGVfcGxheWVyGAIgASgIIjcKD0pvaW5Sb29tUmVxdWVzdBIPCgdyb29tX2lkGAEgASgJEhMKC3BsYXllcl9uYW1lGAIgASgJIlsKEEpvaW5Sb29tUmVzcG9uc2USHQoEcm9vbRgBIAEoCzIPLmJvdW5jZWJvdC5Sb29tEhEKCXBsYXllcl9pZBgCIAEoCRIVCg1zZXNzaW9uX3Rva2VuGAMgASgJIl0KEkNyZWF0ZVJvb21SZXNwb25zZRIdCgRyb29tGAEgASgLMg8uYm91bmNlYm90LlJvb20SEQoJcGxheWVyX2lkGAIgASgJEhUKDXNlc3Npb25fdG9rZW4YAyABKAkiIQoOR2V0Um9vbVJlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCSIjChBTdGFydEdhbWVSZXF1ZXN0Eg8KB3Jvb21faWQYASABKAkiYQoVU3VibWl0U29sdXRpb25SZXF1ZXN0Eg8KB3Jvb21faWQYASABKAkSFQoNc2Vzc2lvbl90b2tlbhgCIAEoCRIgCgVtb3ZlcxgDIAMoCzIRLmJvdW5jZWJvdC5Cb3RQb3MiRQoWU3VibWl0U29sdXRpb25SZXNwb25zZRIrCghzb2x1dGlvbhgBIAEoCzIZLmJvdW5jZWJvdC5QbGF5ZXJTb2x1dGlvbiJEChpNYXJrRmluaXNoZWRTb2x2aW5nUmVxdWVzdBIPCgdyb29tX2lkGAEgASgJEhUKDXNlc3Npb25fdG9rZW4YAiABKAkiLgobTWFya0ZpbmlzaGVkU29sdmluZ1Jlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgiQQoXTWFya1JlYWR5Rm9yTmV4dFJlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCRIVCg1zZXNzaW9uX3Rva2VuGAIgASgJIisKGE1hcmtSZWFkeUZvck5leHRSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIImcKDFNvbHZlclJlc3VsdBITCgtzb2x2ZXJfbmFtZRgBIAEoCRIgCgVtb3ZlcxgCIAMoCzIRLmJvdW5jZWJvdC5Cb3RQb3MSDQoFZXJyb3IYAyABKAkSEQoJY29tcGxldGVkGAQgASgIIm4KGVVwZGF0ZVJvb21TZXR0aW5nc1JlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCRIVCg1zZXNzaW9uX3Rva2VuGAIgASgJEikKCHNldHRpbmdzGAMgASgLMhcuYm91bmNlYm90LlJvb21TZXR0aW5ncyI8ChpVcGRhdGVSb29tU2V0dGluZ3NSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEg0KBWVycm9yGAIgASgJIlUKEUJvb3RQbGF5ZXJSZXF1ZXN0Eg8KB3Jvb21faWQYASABKAkSFQoNc2Vzc2lvbl90b2tlbhgCIAEoCRIYChB0YXJnZXRfcGxheWVyX2lkGAMgASgJIjQKEkJvb3RQbGF5ZXJSZXNwb25zZRIPCgdzdWNjZXNzGAEgASgIEg0KBWVycm9yGAIgASgJIjoKEExlYXZlUm9vbVJlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCRIVCg1zZXNzaW9uX3Rva2VuGAIgASgJIiQKEUxlYXZlUm9vbVJlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgiawoPRGFpbHlQdXp6bGVJbmZvEhIKCmRpZmZpY3VsdHkYASABKAkSHQoEZ2FtZRgCIAEoCzIPLmJvdW5jZWJvdC5HYW1lEg4KBnNvbHZlZBgDIAEoCBIVCg1vcHRpbWFsX21vdmVzGAQgASgFIk4KGEdldERhaWx5Q2hhbGxlbmdlUmVxdWVzdBIRCglwbGF5ZXJfaWQYASABKAkSHwoXdGltZXpvbmVfb2Zmc2V0X21pbnV0ZXMYAiABKAUicwoZR2V0RGFpbHlDaGFsbGVuZ2VSZXNwb25zZRIMCgRkYXRlGAEgASgJEisKB3B1enpsZXMYAiADKAsyGi5ib3VuY2Vib3QuRGFpbHlQdXp6bGVJbmZvEhsKE3NlY29uZHNfdW50aWxfcmVzZXQYAyABKAUicwoaU3VibWl0RGFpbHlTb2x1dGlvblJlcXVlc3QSEQoJcGxheWVyX2lkGAEgASgJEgwKBGRhdGUYAiABKAkSEgoKZGlmZmljdWx0eRgDIAEoCRIgCgVtb3ZlcxgEIAMoCzIRLmJvdW5jZWJvdC5Cb3RQb3MiRgobU3VibWl0RGFpbHlTb2x1dGlvblJlc3BvbnNlEg8KB2NvcnJlY3QYASABKAgSFgoObmV3X2NvbXBsZXRpb24YAiABKAgiFgoUR2V0U2VydmVySW5mb1JlcXVlc3QiOAoVR2V0U2VydmVySW5mb1Jlc3BvbnNlEh8KF2RhaWx5X2NoYWxsZW5nZV9lbmFibGVkGAEgASgIMtEICglCb3VuY2VCb3QSSwoKQ3JlYXRlUm9vbRIcLmJvdW5jZWJvdC5DcmVhdGVSb29tUmVxdWVzdBodLmJvdW5jZWJvdC5DcmVhdGVSb29tUmVzcG9uc2UiABJFCghKb2luUm9vbRIaLmJvdW5jZWJvdC5Kb2luUm9vbVJlcXVlc3QaGy5ib3VuY2Vib3QuSm9pblJvb21SZXNwb25zZSIAEjcKB0dldFJvb20SGS5ib3VuY2Vib3QuR2V0Um9vbVJlcXVlc3QaDy5ib3VuY2Vib3QuUm9vbSIAEjsKCVN0YXJ0R2FtZRIbLmJvdW5jZWJvdC5TdGFydEdhbWVSZXF1ZXN0Gg8uYm91bmNlYm90LlJvb20iABJXCg5TdWJtaXRTb2x1dGlvbhIgLmJvdW5jZWJvdC5TdWJtaXRTb2x1dGlvblJlcXVlc3QaIS5ib3VuY2Vib3QuU3VibWl0U29sdXRpb25SZXNwb25zZSIAEmYKE01hcmtGaW5pc2hlZFNvbHZpbmcSJS5ib3VuY2Vib3QuTWFya0ZpbmlzaGVkU29sdmluZ1JlcXVlc3QaJi5ib3VuY2Vib3QuTWFya0ZpbmlzaGVkU29sdmluZ1Jlc3BvbnNlIgASXQoQTWFya1JlYWR5Rm9yTmV4dBIiLmJvdW5jZWJvdC5NYXJrUmVhZHlGb3JOZXh0UmVxdWVzdBojLmJvdW5jZWJvdC5NYXJrUmVhZHlGb3JOZXh0UmVzcG9uc2UiABJjChJVcGRhdGVSb29tU2V0dGluZ3MSJC5ib3VuY2Vib3QuVXBkYXRlUm9vbVNldHRpbmdzUmVxdWVzdBolLmJvdW5jZWJvdC5VcGRhdGVSb29tU2V0dGluZ3NSZXNwb25zZSIAEksKCkJvb3RQbGF5ZXISHC5ib3VuY2Vib3QuQm9vdFBsYXllclJlcXVlc3QaHS5ib3VuY2Vib3QuQm9vdFBsYXllclJlc3BvbnNlIgASSAoJTGVhdmVSb29tEhsuYm91bmNlYm90LkxlYXZlUm9vbVJlcXVlc3QaHC5ib3VuY2Vib3QuTGVhdmVSb29tUmVzcG9uc2UiABJgChFHZXREYWlseUNoYWxsZW5nZRIjLmJvdW5jZWJvdC5HZXREYWlseUNoYWxsZW5nZVJlcXVlc3QaJC5ib3VuY2Vib3QuR2V0RGFpbHlDaGFsbGVuZ2VSZXNwb25zZSIAEmYKE1N1Ym1pdERhaWx5U29sdXRpb24SJS5ib3VuY2Vib3QuU3VibWl0RGFpbHlTb2x1dGlvblJlcXVlc3QaJi5ib3VuY2Vib3QuU3VibWl0RGFpbHlTb2x1dGlvblJlc3BvbnNlIgASVAoNR2V0U2VydmVySW5mbxIfLmJvdW5jZWJvdC5HZXRTZXJ2ZXJJbmZvUmVxdWVzdBogLmJvdW5jZWJvdC5HZXRTZXJ2ZXJJbmZvUmVzcG9uc2UiAEIoWiZnaXRodWIuY29tL3Nyc2FsaXNidXJ5L2JvdW5jZWJvdC9wcm90b2IGcHJvdG8z", [file_google_protobuf_timestamp]);
+  fileDesc("Cg9ib3VuY2Vib3QucHJvdG8SCWJvdW5jZWJvdCIgCghQb3NpdGlvbhIJCgF4GAEgASgFEgkKAXkYAiABKAUikAEKBUJvYXJkEgwKBHNpemUYASABKAUSJAoHdl93YWxscxgCIAMoCzITLmJvdW5jZWJvdC5Qb3NpdGlvbhIkCgdoX3dhbGxzGAMgAygLMhMuYm91bmNlYm90LlBvc2l0aW9uEi0KEHBvc3NpYmxlX3RhcmdldHMYBCADKAsyEy5ib3VuY2Vib3QuUG9zaXRpb24iNgoGQm90UG9zEgoKAmlkGAEgASgFEiAKA3BvcxgCIAEoCzITLmJvdW5jZWJvdC5Qb3NpdGlvbiJrCgRHYW1lEh8KBWJvYXJkGAEgASgLMhAuYm91bmNlYm90LkJvYXJkEh8KBGJvdHMYAiADKAsyES5ib3VuY2Vib3QuQm90UG9zEiEKBnRhcmdldBgDIAEoCzIRLmJvdW5jZWJvdC5Cb3RQb3MiNwoGUGxheWVyEgoKAmlkGAEgASgJEgwKBG5hbWUYAiABKAkSEwoLY29sb3JfaW5kZXgYAyABKAUidAoOUGxheWVyU29sdXRpb24SEQoJcGxheWVyX2lkGAEgASgJEi0KCXNvbHZlZF9hdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASIAoFbW92ZXMYAyADKAsyES5ib3VuY2Vib3QuQm90UG9zIi4KC1BsYXllclNjb3JlEhEKCXBsYXllcl9pZBgBIAEoCRIMCgR3aW5zGAIgASgFImoKDFJvb21TZXR0aW5ncxIeChZzaG93X3NvbHZlcl9tb3ZlX2NvdW50GAEgASgIEh0KFXNob3dfc29sdmVyX3NvbHV0aW9ucxgCIAEoCBIbChNtaW5fc29sdXRpb25fbGVuZ3RoGAMgASgFIoIECgRSb29tEgoKAmlkGAEgASgJEiIKB3BsYXllcnMYAiADKAsyES5ib3VuY2Vib3QuUGxheWVyEi4KCmNyZWF0ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEiUKDGN1cnJlbnRfZ2FtZRgEIAEoCzIPLmJvdW5jZWJvdC5HYW1lEjMKD2dhbWVfc3RhcnRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLAoJc29sdXRpb25zGAYgAygLMhkuYm91bmNlYm90LlBsYXllclNvbHV0aW9uEiYKBnNjb3JlcxgHIAMoCzIWLmJvdW5jZWJvdC5QbGF5ZXJTY29yZRIUCgxnYW1lc19wbGF5ZWQYCCABKAUSGAoQZmluaXNoZWRfc29sdmluZxgJIAMoCRIWCg5yZWFkeV9mb3JfbmV4dBgKIAMoCRIYChBpc19zaW5nbGVfcGxheWVyGAsgASgIEioKD3BlbmRpbmdfcGxheWVycxgMIAMoCzIRLmJvdW5jZWJvdC5QbGF5ZXISLwoOc29sdmVyX3Jlc3VsdHMYDSADKAsyFy5ib3VuY2Vib3QuU29sdmVyUmVzdWx0EikKCHNldHRpbmdzGA4gASgLMhcuYm91bmNlYm90LlJvb21TZXR0aW5ncyJCChFDcmVhdGVSb29tUmVxdWVzdBITCgtwbGF5ZXJfbmFtZRgBIAEoCRIYChBpc19zaW5nbGVfcGxheWVyGAIgASgIIksKIENyZWF0ZVJvb21Gcm9tU2hhcmVkQm9hcmRSZXF1ZXN0EhMKC3BsYXllcl9uYW1lGAEgASgJEhIKCnNoYXJlX2NvZGUYAiABKAkiNwoPSm9pblJvb21SZXF1ZXN0Eg8KB3Jvb21faWQYASABKAkSEwoLcGxheWVyX25hbWUYAiABKAkiWwoQSm9pblJvb21SZXNwb25zZRIdCgRyb29tGAEgASgLMg8uYm91bmNlYm90LlJvb20SEQoJcGxheWVyX2lkGAIgASgJEhUKDXNlc3Npb25fdG9rZW4YAyABKAkiXQoSQ3JlYXRlUm9vbVJlc3BvbnNlEh0KBHJvb20YASABKAsyDy5ib3VuY2Vib3QuUm9vbRIRCglwbGF5ZXJfaWQYAiABKAkSFQoNc2Vzc2lvbl90b2tlbhgDIAEoCSIhCg5HZXRSb29tUmVxdWVzdBIPCgdyb29tX2lkGAEgASgJIiMKEFN0YXJ0R2FtZVJlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCSJhChVTdWJtaXRTb2x1dGlvblJlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCRIVCg1zZXNzaW9uX3Rva2VuGAIgASgJEiAKBW1vdmVzGAMgAygLMhEuYm91bmNlYm90LkJvdFBvcyJFChZTdWJtaXRTb2x1dGlvblJlc3BvbnNlEisKCHNvbHV0aW9uGAEgASgLMhkuYm91bmNlYm90LlBsYXllclNvbHV0aW9uIkQKGk1hcmtGaW5pc2hlZFNvbHZpbmdSZXF1ZXN0Eg8KB3Jvb21faWQYASABKAkSFQoNc2Vzc2lvbl90b2tlbhgCIAEoCSIuChtNYXJrRmluaXNoZWRTb2x2aW5nUmVzcG9uc2USDwoHc3VjY2VzcxgBIAEoCCJBChdNYXJrUmVhZHlGb3JOZXh0UmVxdWVzdBIPCgdyb29tX2lkGAEgASgJEhUKDXNlc3Npb25fdG9rZW4YAiABKAkiKwoYTWFya1JlYWR5Rm9yTmV4dFJlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgiZwoMU29sdmVyUmVzdWx0EhMKC3NvbHZlcl9uYW1lGAEgASgJEiAKBW1vdmVzGAIgAygLMhEuYm91bmNlYm90LkJvdFBvcxINCgVlcnJvchgDIAEoCRIRCgljb21wbGV0ZWQYBCABKAgibgoZVXBkYXRlUm9vbVNldHRpbmdzUmVxdWVzdBIPCgdyb29tX2lkGAEgASgJEhUKDXNlc3Npb25fdG9rZW4YAiABKAkSKQoIc2V0dGluZ3MYAyABKAsyFy5ib3VuY2Vib3QuUm9vbVNldHRpbmdzIjwKGlVwZGF0ZVJvb21TZXR0aW5nc1Jlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgSDQoFZXJyb3IYAiABKAkiVQoRQm9vdFBsYXllclJlcXVlc3QSDwoHcm9vbV9pZBgBIAEoCRIVCg1zZXNzaW9uX3Rva2VuGAIgASgJEhgKEHRhcmdldF9wbGF5ZXJfaWQYAyABKAkiNAoSQm9vdFBsYXllclJlc3BvbnNlEg8KB3N1Y2Nlc3MYASABKAgSDQoFZXJyb3IYAiABKAkiOgoQTGVhdmVSb29tUmVxdWVzdBIPCgdyb29tX2lkGAEgASgJEhUKDXNlc3Npb25fdG9rZW4YAiABKAkiJAoRTGVhdmVSb29tUmVzcG9uc2USDwoHc3VjY2VzcxgBIAEoCCJrCg9EYWlseVB1enpsZUluZm8SEgoKZGlmZmljdWx0eRgBIAEoCRIdCgRnYW1lGAIgASgLMg8uYm91bmNlYm90LkdhbWUSDgoGc29sdmVkGAMgASgIEhUKDW9wdGltYWxfbW92ZXMYBCABKAUiTgoYR2V0RGFpbHlDaGFsbGVuZ2VSZXF1ZXN0EhEKCXBsYXllcl9pZBgBIAEoCRIfChd0aW1lem9uZV9vZmZzZXRfbWludXRlcxgCIAEoBSJzChlHZXREYWlseUNoYWxsZW5nZVJlc3BvbnNlEgwKBGRhdGUYASABKAkSKwoHcHV6emxlcxgCIAMoCzIaLmJvdW5jZWJvdC5EYWlseVB1enpsZUluZm8SGwoTc2Vjb25kc191bnRpbF9yZXNldBgDIAEoBSJzChpTdWJtaXREYWlseVNvbHV0aW9uUmVxdWVzdBIRCglwbGF5ZXJfaWQYASABKAkSDAoEZGF0ZRgCIAEoCRISCgpkaWZmaWN1bHR5GAMgASgJEiAKBW1vdmVzGAQgAygLMhEuYm91bmNlYm90LkJvdFBvcyJGChtTdWJtaXREYWlseVNvbHV0aW9uUmVzcG9uc2USDwoHY29ycmVjdBgBIAEoCBIWCg5uZXdfY29tcGxldGlvbhgCIAEoCCIWChRHZXRTZXJ2ZXJJbmZvUmVxdWVzdCI4ChVHZXRTZXJ2ZXJJbmZvUmVzcG9uc2USHwoXZGFpbHlfY2hhbGxlbmdlX2VuYWJsZWQYASABKAgyvAkKCUJvdW5jZUJvdBJLCgpDcmVhdGVSb29tEhwuYm91bmNlYm90LkNyZWF0ZVJvb21SZXF1ZXN0Gh0uYm91bmNlYm90LkNyZWF0ZVJvb21SZXNwb25zZSIAEkUKCEpvaW5Sb29tEhouYm91bmNlYm90LkpvaW5Sb29tUmVxdWVzdBobLmJvdW5jZWJvdC5Kb2luUm9vbVJlc3BvbnNlIgASNwoHR2V0Um9vbRIZLmJvdW5jZWJvdC5HZXRSb29tUmVxdWVzdBoPLmJvdW5jZWJvdC5Sb29tIgASOwoJU3RhcnRHYW1lEhsuYm91bmNlYm90LlN0YXJ0R2FtZVJlcXVlc3QaDy5ib3VuY2Vib3QuUm9vbSIAElcKDlN1Ym1pdFNvbHV0aW9uEiAuYm91bmNlYm90LlN1Ym1pdFNvbHV0aW9uUmVxdWVzdBohLmJvdW5jZWJvdC5TdWJtaXRTb2x1dGlvblJlc3BvbnNlIgASZgoTTWFya0ZpbmlzaGVkU29sdmluZxIlLmJvdW5jZWJvdC5NYXJrRmluaXNoZWRTb2x2aW5nUmVxdWVzdBomLmJvdW5jZWJvdC5NYXJrRmluaXNoZWRTb2x2aW5nUmVzcG9uc2UiABJdChBNYXJrUmVhZHlGb3JOZXh0EiIuYm91bmNlYm90Lk1hcmtSZWFkeUZvck5leHRSZXF1ZXN0GiMuYm91bmNlYm90Lk1hcmtSZWFkeUZvck5leHRSZXNwb25zZSIAEmMKElVwZGF0ZVJvb21TZXR0aW5ncxIkLmJvdW5jZWJvdC5VcGRhdGVSb29tU2V0dGluZ3NSZXF1ZXN0GiUuYm91bmNlYm90LlVwZGF0ZVJvb21TZXR0aW5nc1Jlc3BvbnNlIgASSwoKQm9vdFBsYXllchIcLmJvdW5jZWJvdC5Cb290UGxheWVyUmVxdWVzdBodLmJvdW5jZWJvdC5Cb290UGxheWVyUmVzcG9uc2UiABJICglMZWF2ZVJvb20SGy5ib3VuY2Vib3QuTGVhdmVSb29tUmVxdWVzdBocLmJvdW5jZWJvdC5MZWF2ZVJvb21SZXNwb25zZSIAEmkKGUNyZWF0ZVJvb21Gcm9tU2hhcmVkQm9hcmQSKy5ib3VuY2Vib3QuQ3JlYXRlUm9vbUZyb21TaGFyZWRCb2FyZFJlcXVlc3QaHS5ib3VuY2Vib3QuQ3JlYXRlUm9vbVJlc3BvbnNlIgASYAoRR2V0RGFpbHlDaGFsbGVuZ2USIy5ib3VuY2Vib3QuR2V0RGFpbHlDaGFsbGVuZ2VSZXF1ZXN0GiQuYm91bmNlYm90LkdldERhaWx5Q2hhbGxlbmdlUmVzcG9uc2UiABJmChNTdWJtaXREYWlseVNvbHV0aW9uEiUuYm91bmNlYm90LlN1Ym1pdERhaWx5U29sdXRpb25SZXF1ZXN0GiYuYm91bmNlYm90LlN1Ym1pdERhaWx5U29sdXRpb25SZXNwb25zZSIAElQKDUdldFNlcnZlckluZm8SHy5ib3VuY2Vib3QuR2V0U2VydmVySW5mb1JlcXVlc3QaIC5ib3VuY2Vib3QuR2V0U2VydmVySW5mb1Jlc3BvbnNlIgBCKFomZ2l0aHViLmNvbS9zcnNhbGlzYnVyeS9ib3VuY2Vib3QvcHJvdG9iBnByb3RvMw", [file_google_protobuf_timestamp]);
 
 /**
  * Board grid position.
@@ -388,6 +388,32 @@ export const CreateRoomRequestSchema: GenMessage<CreateRoomRequest> = /*@__PURE_
   messageDesc(file_bouncebot, 9);
 
 /**
+ * Creates a new single-player room seeded with a specific board, decoded
+ * from a share code (see planning/BOARD_SHARING_DESIGN.md). Returns the same
+ * shape as CreateRoomResponse.
+ *
+ * @generated from message bouncebot.CreateRoomFromSharedBoardRequest
+ */
+export type CreateRoomFromSharedBoardRequest = Message<"bouncebot.CreateRoomFromSharedBoardRequest"> & {
+  /**
+   * @generated from field: string player_name = 1;
+   */
+  playerName: string;
+
+  /**
+   * @generated from field: string share_code = 2;
+   */
+  shareCode: string;
+};
+
+/**
+ * Describes the message bouncebot.CreateRoomFromSharedBoardRequest.
+ * Use `create(CreateRoomFromSharedBoardRequestSchema)` to create a new message.
+ */
+export const CreateRoomFromSharedBoardRequestSchema: GenMessage<CreateRoomFromSharedBoardRequest> = /*@__PURE__*/
+  messageDesc(file_bouncebot, 10);
+
+/**
  * @generated from message bouncebot.JoinRoomRequest
  */
 export type JoinRoomRequest = Message<"bouncebot.JoinRoomRequest"> & {
@@ -407,7 +433,7 @@ export type JoinRoomRequest = Message<"bouncebot.JoinRoomRequest"> & {
  * Use `create(JoinRoomRequestSchema)` to create a new message.
  */
 export const JoinRoomRequestSchema: GenMessage<JoinRoomRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 10);
+  messageDesc(file_bouncebot, 11);
 
 /**
  * @generated from message bouncebot.JoinRoomResponse
@@ -434,7 +460,7 @@ export type JoinRoomResponse = Message<"bouncebot.JoinRoomResponse"> & {
  * Use `create(JoinRoomResponseSchema)` to create a new message.
  */
 export const JoinRoomResponseSchema: GenMessage<JoinRoomResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 11);
+  messageDesc(file_bouncebot, 12);
 
 /**
  * @generated from message bouncebot.CreateRoomResponse
@@ -461,7 +487,7 @@ export type CreateRoomResponse = Message<"bouncebot.CreateRoomResponse"> & {
  * Use `create(CreateRoomResponseSchema)` to create a new message.
  */
 export const CreateRoomResponseSchema: GenMessage<CreateRoomResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 12);
+  messageDesc(file_bouncebot, 13);
 
 /**
  * @generated from message bouncebot.GetRoomRequest
@@ -478,7 +504,7 @@ export type GetRoomRequest = Message<"bouncebot.GetRoomRequest"> & {
  * Use `create(GetRoomRequestSchema)` to create a new message.
  */
 export const GetRoomRequestSchema: GenMessage<GetRoomRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 13);
+  messageDesc(file_bouncebot, 14);
 
 /**
  * @generated from message bouncebot.StartGameRequest
@@ -495,7 +521,7 @@ export type StartGameRequest = Message<"bouncebot.StartGameRequest"> & {
  * Use `create(StartGameRequestSchema)` to create a new message.
  */
 export const StartGameRequestSchema: GenMessage<StartGameRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 14);
+  messageDesc(file_bouncebot, 15);
 
 /**
  * @generated from message bouncebot.SubmitSolutionRequest
@@ -522,7 +548,7 @@ export type SubmitSolutionRequest = Message<"bouncebot.SubmitSolutionRequest"> &
  * Use `create(SubmitSolutionRequestSchema)` to create a new message.
  */
 export const SubmitSolutionRequestSchema: GenMessage<SubmitSolutionRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 15);
+  messageDesc(file_bouncebot, 16);
 
 /**
  * @generated from message bouncebot.SubmitSolutionResponse
@@ -539,7 +565,7 @@ export type SubmitSolutionResponse = Message<"bouncebot.SubmitSolutionResponse">
  * Use `create(SubmitSolutionResponseSchema)` to create a new message.
  */
 export const SubmitSolutionResponseSchema: GenMessage<SubmitSolutionResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 16);
+  messageDesc(file_bouncebot, 17);
 
 /**
  * @generated from message bouncebot.MarkFinishedSolvingRequest
@@ -561,7 +587,7 @@ export type MarkFinishedSolvingRequest = Message<"bouncebot.MarkFinishedSolvingR
  * Use `create(MarkFinishedSolvingRequestSchema)` to create a new message.
  */
 export const MarkFinishedSolvingRequestSchema: GenMessage<MarkFinishedSolvingRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 17);
+  messageDesc(file_bouncebot, 18);
 
 /**
  * @generated from message bouncebot.MarkFinishedSolvingResponse
@@ -578,7 +604,7 @@ export type MarkFinishedSolvingResponse = Message<"bouncebot.MarkFinishedSolving
  * Use `create(MarkFinishedSolvingResponseSchema)` to create a new message.
  */
 export const MarkFinishedSolvingResponseSchema: GenMessage<MarkFinishedSolvingResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 18);
+  messageDesc(file_bouncebot, 19);
 
 /**
  * @generated from message bouncebot.MarkReadyForNextRequest
@@ -600,7 +626,7 @@ export type MarkReadyForNextRequest = Message<"bouncebot.MarkReadyForNextRequest
  * Use `create(MarkReadyForNextRequestSchema)` to create a new message.
  */
 export const MarkReadyForNextRequestSchema: GenMessage<MarkReadyForNextRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 19);
+  messageDesc(file_bouncebot, 20);
 
 /**
  * @generated from message bouncebot.MarkReadyForNextResponse
@@ -617,7 +643,7 @@ export type MarkReadyForNextResponse = Message<"bouncebot.MarkReadyForNextRespon
  * Use `create(MarkReadyForNextResponseSchema)` to create a new message.
  */
 export const MarkReadyForNextResponseSchema: GenMessage<MarkReadyForNextResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 20);
+  messageDesc(file_bouncebot, 21);
 
 /**
  * Solver result sent via WebSocket when solver completes
@@ -657,7 +683,7 @@ export type SolverResult = Message<"bouncebot.SolverResult"> & {
  * Use `create(SolverResultSchema)` to create a new message.
  */
 export const SolverResultSchema: GenMessage<SolverResult> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 21);
+  messageDesc(file_bouncebot, 22);
 
 /**
  * @generated from message bouncebot.UpdateRoomSettingsRequest
@@ -686,7 +712,7 @@ export type UpdateRoomSettingsRequest = Message<"bouncebot.UpdateRoomSettingsReq
  * Use `create(UpdateRoomSettingsRequestSchema)` to create a new message.
  */
 export const UpdateRoomSettingsRequestSchema: GenMessage<UpdateRoomSettingsRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 22);
+  messageDesc(file_bouncebot, 23);
 
 /**
  * @generated from message bouncebot.UpdateRoomSettingsResponse
@@ -708,7 +734,7 @@ export type UpdateRoomSettingsResponse = Message<"bouncebot.UpdateRoomSettingsRe
  * Use `create(UpdateRoomSettingsResponseSchema)` to create a new message.
  */
 export const UpdateRoomSettingsResponseSchema: GenMessage<UpdateRoomSettingsResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 23);
+  messageDesc(file_bouncebot, 24);
 
 /**
  * @generated from message bouncebot.BootPlayerRequest
@@ -739,7 +765,7 @@ export type BootPlayerRequest = Message<"bouncebot.BootPlayerRequest"> & {
  * Use `create(BootPlayerRequestSchema)` to create a new message.
  */
 export const BootPlayerRequestSchema: GenMessage<BootPlayerRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 24);
+  messageDesc(file_bouncebot, 25);
 
 /**
  * @generated from message bouncebot.BootPlayerResponse
@@ -761,7 +787,7 @@ export type BootPlayerResponse = Message<"bouncebot.BootPlayerResponse"> & {
  * Use `create(BootPlayerResponseSchema)` to create a new message.
  */
 export const BootPlayerResponseSchema: GenMessage<BootPlayerResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 25);
+  messageDesc(file_bouncebot, 26);
 
 /**
  * @generated from message bouncebot.LeaveRoomRequest
@@ -783,7 +809,7 @@ export type LeaveRoomRequest = Message<"bouncebot.LeaveRoomRequest"> & {
  * Use `create(LeaveRoomRequestSchema)` to create a new message.
  */
 export const LeaveRoomRequestSchema: GenMessage<LeaveRoomRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 26);
+  messageDesc(file_bouncebot, 27);
 
 /**
  * @generated from message bouncebot.LeaveRoomResponse
@@ -800,7 +826,7 @@ export type LeaveRoomResponse = Message<"bouncebot.LeaveRoomResponse"> & {
  * Use `create(LeaveRoomResponseSchema)` to create a new message.
  */
 export const LeaveRoomResponseSchema: GenMessage<LeaveRoomResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 27);
+  messageDesc(file_bouncebot, 28);
 
 /**
  * Daily challenge messages
@@ -836,7 +862,7 @@ export type DailyPuzzleInfo = Message<"bouncebot.DailyPuzzleInfo"> & {
  * Use `create(DailyPuzzleInfoSchema)` to create a new message.
  */
 export const DailyPuzzleInfoSchema: GenMessage<DailyPuzzleInfo> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 28);
+  messageDesc(file_bouncebot, 29);
 
 /**
  * @generated from message bouncebot.GetDailyChallengeRequest
@@ -858,7 +884,7 @@ export type GetDailyChallengeRequest = Message<"bouncebot.GetDailyChallengeReque
  * Use `create(GetDailyChallengeRequestSchema)` to create a new message.
  */
 export const GetDailyChallengeRequestSchema: GenMessage<GetDailyChallengeRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 29);
+  messageDesc(file_bouncebot, 30);
 
 /**
  * @generated from message bouncebot.GetDailyChallengeResponse
@@ -885,7 +911,7 @@ export type GetDailyChallengeResponse = Message<"bouncebot.GetDailyChallengeResp
  * Use `create(GetDailyChallengeResponseSchema)` to create a new message.
  */
 export const GetDailyChallengeResponseSchema: GenMessage<GetDailyChallengeResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 30);
+  messageDesc(file_bouncebot, 31);
 
 /**
  * @generated from message bouncebot.SubmitDailySolutionRequest
@@ -917,7 +943,7 @@ export type SubmitDailySolutionRequest = Message<"bouncebot.SubmitDailySolutionR
  * Use `create(SubmitDailySolutionRequestSchema)` to create a new message.
  */
 export const SubmitDailySolutionRequestSchema: GenMessage<SubmitDailySolutionRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 31);
+  messageDesc(file_bouncebot, 32);
 
 /**
  * @generated from message bouncebot.SubmitDailySolutionResponse
@@ -939,7 +965,7 @@ export type SubmitDailySolutionResponse = Message<"bouncebot.SubmitDailySolution
  * Use `create(SubmitDailySolutionResponseSchema)` to create a new message.
  */
 export const SubmitDailySolutionResponseSchema: GenMessage<SubmitDailySolutionResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 32);
+  messageDesc(file_bouncebot, 33);
 
 /**
  * @generated from message bouncebot.GetServerInfoRequest
@@ -952,7 +978,7 @@ export type GetServerInfoRequest = Message<"bouncebot.GetServerInfoRequest"> & {
  * Use `create(GetServerInfoRequestSchema)` to create a new message.
  */
 export const GetServerInfoRequestSchema: GenMessage<GetServerInfoRequest> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 33);
+  messageDesc(file_bouncebot, 34);
 
 /**
  * @generated from message bouncebot.GetServerInfoResponse
@@ -969,7 +995,7 @@ export type GetServerInfoResponse = Message<"bouncebot.GetServerInfoResponse"> &
  * Use `create(GetServerInfoResponseSchema)` to create a new message.
  */
 export const GetServerInfoResponseSchema: GenMessage<GetServerInfoResponse> = /*@__PURE__*/
-  messageDesc(file_bouncebot, 34);
+  messageDesc(file_bouncebot, 35);
 
 /**
  * Service for client to fetch a game board and return results.
@@ -1058,6 +1084,14 @@ export const BounceBot: GenService<{
     methodKind: "unary";
     input: typeof LeaveRoomRequestSchema;
     output: typeof LeaveRoomResponseSchema;
+  },
+  /**
+   * @generated from rpc bouncebot.BounceBot.CreateRoomFromSharedBoard
+   */
+  createRoomFromSharedBoard: {
+    methodKind: "unary";
+    input: typeof CreateRoomFromSharedBoardRequestSchema;
+    output: typeof CreateRoomResponseSchema;
   },
   /**
    * Daily challenge

--- a/client/web/src/router.ts
+++ b/client/web/src/router.ts
@@ -4,6 +4,7 @@ import RoomView from './views/RoomView.vue'
 import HelpView from './views/HelpView.vue'
 import DailyChallengeView from './views/DailyChallengeView.vue'
 import DailyGameView from './views/DailyGameView.vue'
+import ShareLandingView from './views/ShareLandingView.vue'
 import { config } from './config'
 import { useFeatureStore } from './stores/featureStore'
 
@@ -35,6 +36,12 @@ const router = createRouter({
       path: '/daily/:difficulty',
       name: 'daily-game',
       component: DailyGameView,
+      props: true,
+    },
+    {
+      path: '/share/:code',
+      name: 'share',
+      component: ShareLandingView,
       props: true,
     },
   ],

--- a/client/web/src/shareCode.test.ts
+++ b/client/web/src/shareCode.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import { GameSchema, BoardSchema, BotPosSchema, PositionSchema, type Game } from './gen/bouncebot_pb'
+import { encodeShareCode, decodeShareCode, ShareCodeError } from './shareCode'
+
+// Mirrors model.Game1() in the Go codebase exactly (same board, bots,
+// target) - dumped directly from a running instance of that function, so
+// this file and model/share_code_test.go can share the same fixed vector.
+const GAME1_SHARE_CODE = 'ARAZEDESYyZn4ragpIGHv57cq8p6iB4ZTUhfaBlAEWMFNnb04cWkkYad7KvZifiICx4oTFh4EUESYzbixqSRnuyr2ooeKU1YAE1UrDnEkw'
+
+function pos(x: number, y: number) {
+  return create(PositionSchema, { x, y })
+}
+
+function game1(): Game {
+  const vWalls = [
+    [1, 0], [3, 1], [1, 2], [6, 3], [2, 6], [6, 7], [14, 2], [11, 6], [10, 0],
+    [10, 4], [8, 1], [8, 7], [11, 15], [9, 14], [13, 12], [10, 11], [12, 10],
+    [7, 10], [8, 8], [1, 14], [1, 9], [4, 13], [4, 8], [5, 15], [6, 8],
+  ].map(([x, y]) => pos(x!, y!))
+
+  const hWalls = [
+    [4, 0], [1, 1], [6, 3], [0, 5], [3, 6], [7, 6], [15, 4], [14, 1], [12, 5],
+    [10, 4], [9, 1], [8, 6], [9, 13], [14, 12], [10, 11], [13, 9], [8, 9],
+    [15, 8], [8, 8], [0, 11], [1, 14], [2, 8], [4, 12], [5, 8], [7, 8],
+  ].map(([x, y]) => pos(x!, y!))
+
+  const possibleTargets = [
+    [4, 1], [1, 2], [6, 3], [3, 6], [14, 2], [12, 6], [10, 4], [9, 1], [9, 14],
+    [14, 12], [10, 11], [13, 10], [8, 10], [1, 14], [2, 9], [4, 13], [5, 8],
+  ].map(([x, y]) => pos(x!, y!))
+
+  const board = create(BoardSchema, { size: 16, vWalls, hWalls, possibleTargets })
+
+  const bots = [
+    create(BotPosSchema, { id: 0, pos: pos(5, 4) }),
+    create(BotPosSchema, { id: 1, pos: pos(10, 12) }),
+    create(BotPosSchema, { id: 2, pos: pos(3, 9) }),
+    create(BotPosSchema, { id: 3, pos: pos(12, 4) }),
+  ]
+
+  const target = create(BotPosSchema, { id: 0, pos: pos(4, 13) })
+
+  return create(GameSchema, { board, bots, target })
+}
+
+describe('shareCode', () => {
+  it('encodes Game1 to the same fixed vector as the Go implementation', () => {
+    expect(encodeShareCode(game1())).toBe(GAME1_SHARE_CODE)
+  })
+
+  it('decodes the fixed vector back to Game1\'s data', () => {
+    const decoded = decodeShareCode(GAME1_SHARE_CODE)
+    expect(decoded.size).toBe(16)
+    expect(decoded.vWalls).toHaveLength(25)
+    expect(decoded.hWalls).toHaveLength(25)
+    expect(decoded.possibleTargets).toHaveLength(17)
+    expect(decoded.targetBotId).toBe(0)
+    expect(decoded.targetPos).toEqual({ x: 4, y: 13 })
+    expect(decoded.bots).toEqual([
+      { x: 5, y: 4 },
+      { x: 10, y: 12 },
+      { x: 3, y: 9 },
+      { x: 12, y: 4 },
+    ])
+  })
+
+  it('round-trips a real game', () => {
+    const code = encodeShareCode(game1())
+    const decoded = decodeShareCode(code)
+    expect(decoded.vWalls).toHaveLength(25)
+    expect(decoded.hWalls).toHaveLength(25)
+    expect(decoded.possibleTargets).toHaveLength(17)
+    expect(decoded.targetBotId).toBe(0)
+    expect(decoded.targetPos).toEqual({ x: 4, y: 13 })
+  })
+
+  it('rejects a truncated code', () => {
+    const code = encodeShareCode(game1())
+    expect(() => decodeShareCode(code.slice(0, code.length / 2))).toThrow(ShareCodeError)
+  })
+
+  it('rejects a corrupted checksum', () => {
+    const code = encodeShareCode(game1())
+    const lastChar = code[code.length - 1]
+    const replacement = lastChar === 'A' ? 'B' : 'A'
+    const corrupted = code.slice(0, -1) + replacement
+    expect(() => decodeShareCode(corrupted)).toThrow(ShareCodeError)
+  })
+
+  it('rejects invalid base64', () => {
+    expect(() => decodeShareCode('not valid base64url!!!')).toThrow(ShareCodeError)
+  })
+
+  it('rejects an empty code', () => {
+    expect(() => decodeShareCode('')).toThrow(ShareCodeError)
+  })
+
+  it('rejects a missing target', () => {
+    const game = create(GameSchema, {
+      board: create(BoardSchema, { size: 16, vWalls: [], hWalls: [], possibleTargets: [] }),
+      bots: [
+        create(BotPosSchema, { id: 0, pos: pos(0, 0) }),
+        create(BotPosSchema, { id: 1, pos: pos(1, 0) }),
+        create(BotPosSchema, { id: 2, pos: pos(2, 0) }),
+        create(BotPosSchema, { id: 3, pos: pos(3, 0) }),
+      ],
+    })
+    expect(() => encodeShareCode(game)).toThrow(ShareCodeError)
+  })
+
+  it('rejects out-of-range coordinates', () => {
+    const game = create(GameSchema, {
+      board: create(BoardSchema, { size: 20, vWalls: [], hWalls: [], possibleTargets: [pos(19, 19)] }),
+      bots: [
+        create(BotPosSchema, { id: 0, pos: pos(0, 0) }),
+        create(BotPosSchema, { id: 1, pos: pos(1, 0) }),
+        create(BotPosSchema, { id: 2, pos: pos(2, 0) }),
+        create(BotPosSchema, { id: 3, pos: pos(3, 0) }),
+      ],
+      target: create(BotPosSchema, { id: 0, pos: pos(19, 19) }),
+    })
+    expect(() => encodeShareCode(game)).toThrow(ShareCodeError)
+  })
+})

--- a/client/web/src/shareCode.ts
+++ b/client/web/src/shareCode.ts
@@ -147,7 +147,11 @@ function checksum(bytes: number[]): number {
 
 class ByteReader {
   private pos = 0
-  constructor(private buf: Uint8Array) {}
+  private buf: Uint8Array
+
+  constructor(buf: Uint8Array) {
+    this.buf = buf
+  }
 
   readByte(): number {
     if (this.pos >= this.buf.length) {

--- a/client/web/src/shareCode.ts
+++ b/client/web/src/shareCode.ts
@@ -1,0 +1,195 @@
+import type { Game } from './gen/bouncebot_pb'
+
+// See planning/BOARD_SHARING_DESIGN.md for the full byte layout. This must
+// stay byte-for-byte compatible with model/share_code.go's Go implementation
+// - shareCode.test.ts checks both against the same fixed vector to catch
+// drift between the two.
+
+const SHARE_CODE_VERSION = 1
+const SHARE_CODE_MAX_COORD = 15
+
+export class ShareCodeError extends Error {}
+
+interface PlainPosition {
+  x: number
+  y: number
+}
+
+/** The result of decoding a share code - a plain, proto-independent shape. */
+export interface DecodedShareCode {
+  size: number
+  vWalls: PlainPosition[]
+  hWalls: PlainPosition[]
+  possibleTargets: PlainPosition[]
+  targetBotId: number
+  targetPos: PlainPosition
+  bots: PlainPosition[] // indexed by bot id 0-3
+}
+
+/**
+ * Encodes a game's board (walls and possible targets), robot positions, and
+ * target into a short, URL-safe token that the server's DecodeShareCode
+ * (model/share_code.go) can turn back into an identical game.
+ */
+export function encodeShareCode(game: Game): string {
+  const board = game.board
+  if (!board) throw new ShareCodeError('game has no board')
+  if (board.size <= 0 || board.size > SHARE_CODE_MAX_COORD + 1) {
+    throw new ShareCodeError(`board size ${board.size} out of range for share codes (max ${SHARE_CODE_MAX_COORD + 1})`)
+  }
+
+  const { vWalls, hWalls, possibleTargets } = board
+  if (vWalls.length > 255 || hWalls.length > 255 || possibleTargets.length > 255) {
+    throw new ShareCodeError('board has too many walls/targets to encode as a share code')
+  }
+
+  const target = game.target
+  if (!target || !target.pos) throw new ShareCodeError('game has no target')
+  if (target.id < 0 || target.id > 3) {
+    throw new ShareCodeError(`target bot id ${target.id} out of range`)
+  }
+
+  const bytes: number[] = [SHARE_CODE_VERSION, board.size]
+
+  appendPositions(bytes, vWalls)
+  appendPositions(bytes, hWalls)
+  appendPositions(bytes, possibleTargets)
+
+  bytes.push(target.id)
+  bytes.push(packPosition(target.pos))
+
+  for (let id = 0; id < 4; id++) {
+    const bot = game.bots.find(b => b.id === id)
+    if (!bot || !bot.pos) throw new ShareCodeError(`missing bot ${id}`)
+    bytes.push(packPosition(bot.pos))
+  }
+
+  bytes.push(checksum(bytes))
+
+  return toBase64Url(new Uint8Array(bytes))
+}
+
+/**
+ * Reverses encodeShareCode. Not used by the production app (the server
+ * decodes when consuming a share link) - kept so tests can verify this
+ * implementation round-trips and agrees with the Go one on the same fixed
+ * vectors.
+ */
+export function decodeShareCode(code: string): DecodedShareCode {
+  const buf = fromBase64Url(code)
+  if (buf.length < 1) {
+    throw new ShareCodeError('share code too short')
+  }
+
+  const payload = buf.slice(0, buf.length - 1)
+  const gotSum = buf[buf.length - 1]
+  if (checksum(Array.from(payload)) !== gotSum) {
+    throw new ShareCodeError('share code failed checksum validation')
+  }
+
+  const r = new ByteReader(payload)
+
+  const version = r.readByte()
+  if (version !== SHARE_CODE_VERSION) {
+    throw new ShareCodeError(`unknown share code version ${version}`)
+  }
+
+  const size = r.readByte()
+  if (size === 0) {
+    throw new ShareCodeError('invalid board size 0')
+  }
+
+  const vWalls = r.readPositions()
+  const hWalls = r.readPositions()
+  const possibleTargets = r.readPositions()
+
+  const targetBotId = r.readByte()
+  if (targetBotId > 3) {
+    throw new ShareCodeError(`target bot id ${targetBotId} out of range`)
+  }
+  const targetPos = r.readPosition()
+
+  const bots: PlainPosition[] = []
+  for (let id = 0; id < 4; id++) {
+    bots.push(r.readPosition())
+  }
+
+  if (!r.atEnd()) {
+    throw new ShareCodeError('share code has unexpected trailing data')
+  }
+
+  return { size, vWalls, hWalls, possibleTargets, targetBotId, targetPos, bots }
+}
+
+function appendPositions(bytes: number[], positions: PlainPosition[]): void {
+  bytes.push(positions.length)
+  for (const p of positions) {
+    bytes.push(packPosition(p))
+  }
+}
+
+function packPosition(p: PlainPosition): number {
+  if (p.x < 0 || p.x > SHARE_CODE_MAX_COORD || p.y < 0 || p.y > SHARE_CODE_MAX_COORD) {
+    throw new ShareCodeError(`position (${p.x}, ${p.y}) out of range for share codes (max ${SHARE_CODE_MAX_COORD})`)
+  }
+  return ((p.x & 0x0f) << 4) | (p.y & 0x0f)
+}
+
+function unpackPosition(b: number): PlainPosition {
+  return { x: (b >> 4) & 0x0f, y: b & 0x0f }
+}
+
+function checksum(bytes: number[]): number {
+  let sum = 0
+  for (const b of bytes) sum = (sum + b) & 0xff
+  return sum
+}
+
+class ByteReader {
+  private pos = 0
+  constructor(private buf: Uint8Array) {}
+
+  readByte(): number {
+    if (this.pos >= this.buf.length) {
+      throw new ShareCodeError('share code truncated')
+    }
+    return this.buf[this.pos++]!
+  }
+
+  readPosition(): PlainPosition {
+    return unpackPosition(this.readByte())
+  }
+
+  readPositions(): PlainPosition[] {
+    const count = this.readByte()
+    const result: PlainPosition[] = []
+    for (let i = 0; i < count; i++) {
+      result.push(this.readPosition())
+    }
+    return result
+  }
+
+  atEnd(): boolean {
+    return this.pos === this.buf.length
+  }
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function fromBase64Url(str: string): Uint8Array {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+  let binary: string
+  try {
+    binary = atob(padded)
+  } catch {
+    throw new ShareCodeError('invalid share code encoding')
+  }
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}

--- a/client/web/src/views/RoomView.vue
+++ b/client/web/src/views/RoomView.vue
@@ -10,9 +10,11 @@ import GameBoard from '../components/GameBoard.vue'
 import PlayersPanel from '../components/PlayersPanel.vue'
 import LeaderboardModal from '../components/LeaderboardModal.vue'
 import SettingsModal from '../components/SettingsModal.vue'
+import ShareModal from '../components/ShareModal.vue'
 import { getPlayerColor, SOLVER_PLAYER_ID, SOLO_PLAYER_ID } from '../constants'
 import { create } from '@bufbuild/protobuf'
 import { PlayerSolutionSchema, BotPosSchema, PositionSchema } from '../gen/bouncebot_pb'
+import { encodeShareCode } from '../shareCode'
 
 const props = defineProps<{
   roomId: string
@@ -31,6 +33,8 @@ const showLeaderboard = ref(false)
 const showLeaveConfirm = ref(false)
 const showStatsDropdown = ref(false)
 const showSettings = ref(false)
+const showShareModal = ref(false)
+const shareBoardUrl = ref('')
 
 // Room connection composable
 const {
@@ -282,6 +286,18 @@ async function copyShareUrl() {
   }
 }
 
+function openShareModal() {
+  if (!room.value?.currentGame) return
+  try {
+    const code = encodeShareCode(room.value.currentGame)
+    const path = router.resolve({ name: 'share', params: { code } }).href
+    shareBoardUrl.value = `${window.location.origin}${path}`
+    showShareModal.value = true
+  } catch (e) {
+    console.error('Failed to create a share link for this board', e)
+  }
+}
+
 async function updateSettings(settings: {
   showSolverMoveCount: boolean
   showSolverSolutions: boolean
@@ -460,7 +476,7 @@ async function bootPlayer(targetPlayerId: string) {
 
 function globalKeyHandler(event: KeyboardEvent) {
   // Don't handle if any dialog is open
-  if (showProtectedSolutionDialog.value || showLeaveConfirm.value || showSettings.value) return
+  if (showProtectedSolutionDialog.value || showLeaveConfirm.value || showSettings.value || showShareModal.value) return
 
   if (event.key === 'l' && (hasGame.value || gameEnded.value)) {
     event.preventDefault()
@@ -506,6 +522,23 @@ watch(showSettings, (show) => {
     window.addEventListener('keydown', settingsKeyHandler, true)
   } else {
     window.removeEventListener('keydown', settingsKeyHandler, true)
+  }
+})
+
+function shareModalKeyHandler(event: KeyboardEvent) {
+  if (!showShareModal.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    showShareModal.value = false
+  }
+}
+
+watch(showShareModal, (show) => {
+  if (show) {
+    window.addEventListener('keydown', shareModalKeyHandler, true)
+  } else {
+    window.removeEventListener('keydown', shareModalKeyHandler, true)
   }
 })
 
@@ -593,6 +626,7 @@ onUnmounted(() => {
         :get-best-submitted-index="gameActions.getBestSubmittedIndex"
         :on-solution-deleted="gameActions.notifySolutionDeleted"
         :player-color="currentPlayerColor"
+        @share="openShareModal"
       >
         <template #header="{ toggleHelp }">
           <div class="game-header">
@@ -804,6 +838,13 @@ onUnmounted(() => {
       @close="showSettings = false"
       @update="updateSettings"
       @boot-player="bootPlayer"
+    />
+
+    <!-- Share board modal -->
+    <ShareModal
+      :show="showShareModal"
+      :url="shareBoardUrl"
+      @close="showShareModal = false"
     />
   </div>
 </template>

--- a/client/web/src/views/ShareLandingView.vue
+++ b/client/web/src/views/ShareLandingView.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useRoomStore } from '../stores/roomStore'
+import { bounceBotClient } from '../services/connectClient'
+
+const props = defineProps<{
+  code: string
+}>()
+
+const router = useRouter()
+const roomStore = useRoomStore()
+
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    // Matches HomeView.vue's startSoloGame bootstrap: fixed default player
+    // name, no prompt, straight into solo play - just seeded with the
+    // shared board instead of a random one.
+    const response = await bounceBotClient.createRoomFromSharedBoard({
+      playerName: 'Player',
+      shareCode: props.code,
+    })
+    roomStore.setCurrentPlayerId(response.playerId, response.sessionToken)
+    roomStore.setSinglePlayer(true)
+
+    // Apply saved display settings, same as any other new solo room.
+    if (roomStore.showSolverMoveCount || roomStore.showSolverSolutions || roomStore.minSolutionLength > 1) {
+      await bounceBotClient.updateRoomSettings({
+        roomId: response.room!.id,
+        sessionToken: response.sessionToken,
+        settings: {
+          showSolverMoveCount: roomStore.showSolverMoveCount,
+          showSolverSolutions: roomStore.showSolverSolutions,
+          minSolutionLength: roomStore.minSolutionLength,
+        },
+      })
+    }
+
+    // replace, not push - this landing route is a one-shot redirect, not
+    // somewhere the back button should return to.
+    router.replace(`/room/${response.room!.id}`)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to open this shared board'
+  }
+})
+</script>
+
+<template>
+  <div class="share-landing">
+    <div v-if="error" class="error-card">
+      <h1>Link Unavailable</h1>
+      <p>This link looks broken, or it came from a newer version of BounceBot.</p>
+      <router-link to="/" class="btn">Back to Home</router-link>
+    </div>
+    <div v-else class="loading">
+      Loading shared board&hellip;
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.share-landing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+.loading {
+  color: #aaa;
+  font-size: 1.1rem;
+}
+
+.error-card {
+  max-width: 360px;
+}
+
+.error-card h1 {
+  color: #ff6b6b;
+  font-size: 1.4rem;
+  margin: 0 0 0.75rem;
+}
+
+.error-card p {
+  color: #aaa;
+  margin: 0 0 1.5rem;
+  line-height: 1.5;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  background: #43a047;
+  color: #fff;
+  text-decoration: none;
+}
+
+.btn:hover {
+  background: #388e3c;
+}
+
+@media (prefers-color-scheme: light) {
+  .loading {
+    color: #666;
+  }
+
+  .error-card p {
+    color: #666;
+  }
+}
+</style>

--- a/model/share_code.go
+++ b/model/share_code.go
@@ -1,0 +1,229 @@
+package model
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// shareCodeVersion is the current share code format version. See
+// planning/BOARD_SHARING_DESIGN.md for the full byte layout.
+const shareCodeVersion = 1
+
+// shareCodeMaxCoord is the largest coordinate value (in either dimension)
+// that can be packed into a share code, since each coordinate is packed into
+// a 4-bit nibble.
+const shareCodeMaxCoord = 15
+
+// EncodeShareCode encodes a game's board (walls and possible targets), robot
+// positions, and target into a short, URL-safe token that DecodeShareCode
+// can turn back into an identical game.
+func EncodeShareCode(game *Game) (string, error) {
+	size := game.Board.Size()
+	if size <= 0 || size > shareCodeMaxCoord+1 {
+		return "", fmt.Errorf("board size %d out of range for share codes (max %d)", size, shareCodeMaxCoord+1)
+	}
+
+	vWalls := game.Board.VWalls()
+	hWalls := game.Board.HWalls()
+	targets := game.Board.PossibleTargets()
+	if len(vWalls) > 255 || len(hWalls) > 255 || len(targets) > 255 {
+		return "", fmt.Errorf("board has too many walls/targets to encode as a share code")
+	}
+
+	if game.Target.Id < 0 || game.Target.Id > 3 {
+		return "", fmt.Errorf("target bot id %d out of range", game.Target.Id)
+	}
+
+	buf := make([]byte, 0, 96)
+	buf = append(buf, shareCodeVersion, byte(size))
+
+	var err error
+	if buf, err = appendPositions(buf, vWalls); err != nil {
+		return "", err
+	}
+	if buf, err = appendPositions(buf, hWalls); err != nil {
+		return "", err
+	}
+	if buf, err = appendPositions(buf, targets); err != nil {
+		return "", err
+	}
+
+	buf = append(buf, byte(game.Target.Id))
+	targetByte, err := packPosition(game.Target.Pos)
+	if err != nil {
+		return "", err
+	}
+	buf = append(buf, targetByte)
+
+	for id := BotId(0); id < 4; id++ {
+		pos, ok := game.Bots[id]
+		if !ok {
+			return "", fmt.Errorf("missing bot %d", id)
+		}
+		b, err := packPosition(pos)
+		if err != nil {
+			return "", err
+		}
+		buf = append(buf, b)
+	}
+
+	buf = append(buf, checksum(buf))
+
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// DecodeShareCode reverses EncodeShareCode. The resulting game is validated
+// the same way any other game is (see NewGame) - malformed or corrupted
+// input never panics, only returns an error.
+func DecodeShareCode(code string) (*Game, error) {
+	buf, err := base64.RawURLEncoding.DecodeString(code)
+	if err != nil {
+		return nil, fmt.Errorf("invalid share code: %w", err)
+	}
+	if len(buf) < 1 {
+		return nil, fmt.Errorf("share code too short")
+	}
+
+	payload, gotSum := buf[:len(buf)-1], buf[len(buf)-1]
+	if checksum(payload) != gotSum {
+		return nil, fmt.Errorf("share code failed checksum validation")
+	}
+
+	r := &byteReader{buf: payload}
+
+	version, err := r.readByte()
+	if err != nil {
+		return nil, err
+	}
+	if version != shareCodeVersion {
+		return nil, fmt.Errorf("unknown share code version %d", version)
+	}
+
+	sizeByte, err := r.readByte()
+	if err != nil {
+		return nil, err
+	}
+	if sizeByte == 0 {
+		return nil, fmt.Errorf("invalid board size 0")
+	}
+	size := BoardDim(sizeByte)
+
+	vWalls, err := r.readPositions()
+	if err != nil {
+		return nil, err
+	}
+	hWalls, err := r.readPositions()
+	if err != nil {
+		return nil, err
+	}
+	targets, err := r.readPositions()
+	if err != nil {
+		return nil, err
+	}
+
+	targetIDByte, err := r.readByte()
+	if err != nil {
+		return nil, err
+	}
+	if targetIDByte > 3 {
+		return nil, fmt.Errorf("target bot id %d out of range", targetIDByte)
+	}
+	targetPos, err := r.readPosition()
+	if err != nil {
+		return nil, err
+	}
+
+	bots := make(map[BotId]Position, 4)
+	for id := BotId(0); id < 4; id++ {
+		pos, err := r.readPosition()
+		if err != nil {
+			return nil, err
+		}
+		bots[id] = pos
+	}
+
+	if !r.atEnd() {
+		return nil, fmt.Errorf("share code has unexpected trailing data")
+	}
+
+	board := NewBoardWithTargets(size, vWalls, hWalls, targets)
+	target := BotPosition{Id: BotId(targetIDByte), Pos: targetPos}
+
+	return NewGame(board, bots, target)
+}
+
+func appendPositions(buf []byte, positions []Position) ([]byte, error) {
+	buf = append(buf, byte(len(positions)))
+	for _, p := range positions {
+		b, err := packPosition(p)
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, b)
+	}
+	return buf, nil
+}
+
+func packPosition(p Position) (byte, error) {
+	if p.X < 0 || p.X > shareCodeMaxCoord || p.Y < 0 || p.Y > shareCodeMaxCoord {
+		return 0, fmt.Errorf("position %v out of range for share codes (max %d)", p, shareCodeMaxCoord)
+	}
+	return byte(p.X)<<4 | byte(p.Y), nil
+}
+
+func unpackPosition(b byte) Position {
+	return Position{X: BoardDim(b >> 4), Y: BoardDim(b & 0x0F)}
+}
+
+func checksum(data []byte) byte {
+	var sum byte
+	for _, b := range data {
+		sum += b
+	}
+	return sum
+}
+
+// byteReader is a small cursor over a byte slice used by DecodeShareCode.
+// Every read is bounds-checked, so a truncated/corrupted token always
+// produces an error rather than a panic.
+type byteReader struct {
+	buf []byte
+	pos int
+}
+
+func (r *byteReader) readByte() (byte, error) {
+	if r.pos >= len(r.buf) {
+		return 0, fmt.Errorf("share code truncated")
+	}
+	b := r.buf[r.pos]
+	r.pos++
+	return b, nil
+}
+
+func (r *byteReader) readPosition() (Position, error) {
+	b, err := r.readByte()
+	if err != nil {
+		return Position{}, err
+	}
+	return unpackPosition(b), nil
+}
+
+func (r *byteReader) readPositions() ([]Position, error) {
+	count, err := r.readByte()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]Position, count)
+	for i := range result {
+		pos, err := r.readPosition()
+		if err != nil {
+			return nil, err
+		}
+		result[i] = pos
+	}
+	return result, nil
+}
+
+func (r *byteReader) atEnd() bool {
+	return r.pos == len(r.buf)
+}

--- a/model/share_code_test.go
+++ b/model/share_code_test.go
@@ -1,0 +1,147 @@
+package model
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// game1ShareCode is a fixed vector: the exact expected encoding of Game1().
+// The TypeScript implementation has a test asserting this same string, to
+// guarantee the two implementations agree byte-for-byte.
+const game1ShareCode = "ARAZEDESYyZn4ragpIGHv57cq8p6iB4ZTUhfaBlAEWMFNnb04cWkkYad7KvZifiICx4oTFh4EUESYzbixqSRnuyr2ooeKU1YAE1UrDnEkw"
+
+func TestEncodeShareCode_FixedVector(t *testing.T) {
+	code, err := EncodeShareCode(Game1())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != game1ShareCode {
+		t.Errorf("EncodeShareCode(Game1()) = %q, want %q (this must match the TypeScript implementation's fixed vector - if this changed intentionally, update both)", code, game1ShareCode)
+	}
+}
+
+func TestDecodeShareCode_FixedVector(t *testing.T) {
+	game, err := DecodeShareCode(game1ShareCode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !game.Equals(Game1()) {
+		t.Errorf("DecodeShareCode(game1ShareCode) did not reproduce Game1():\ngot:\n%s\nwant:\n%s", game.String(), Game1().String())
+	}
+}
+
+func TestShareCode_RoundTrip(t *testing.T) {
+	games := []*Game{Game1()}
+	for i := 0; i < 10; i++ {
+		games = append(games, NewRandomGame())
+	}
+
+	for i, original := range games {
+		code, err := EncodeShareCode(original)
+		if err != nil {
+			t.Fatalf("game %d: EncodeShareCode failed: %v", i, err)
+		}
+		decoded, err := DecodeShareCode(code)
+		if err != nil {
+			t.Fatalf("game %d: DecodeShareCode failed: %v", i, err)
+		}
+		if !decoded.Equals(original) {
+			t.Errorf("game %d: round-trip mismatch:\noriginal:\n%s\ndecoded:\n%s", i, original.String(), decoded.String())
+		}
+	}
+}
+
+func TestShareCode_ContinuationAfterDecode(t *testing.T) {
+	// Regression guard for the exact bug fixed earlier this session
+	// (NewContinuationGame panicking on a board with no possible targets) -
+	// a decoded shared board must be just as usable for a next round as any
+	// other game.
+	code, err := EncodeShareCode(NewRandomGame())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	decoded, err := DecodeShareCode(code)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(decoded.Board.PossibleTargets()) == 0 {
+		t.Fatal("decoded board has no possible targets - continuation would silently fall back to a random game")
+	}
+	// Must not panic.
+	NewContinuationGame(decoded)
+}
+
+func TestDecodeShareCode_BadChecksum(t *testing.T) {
+	code, err := EncodeShareCode(Game1())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Flip the last character (the checksum byte's encoding) to corrupt it.
+	last := code[len(code)-1]
+	replacement := byte('A')
+	if last == 'A' {
+		replacement = 'B'
+	}
+	corrupted := code[:len(code)-1] + string(replacement)
+
+	if _, err := DecodeShareCode(corrupted); err == nil {
+		t.Error("expected an error for a corrupted checksum, got nil")
+	}
+}
+
+func TestDecodeShareCode_Truncated(t *testing.T) {
+	code, err := EncodeShareCode(Game1())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	truncated := code[:len(code)/2]
+
+	if _, err := DecodeShareCode(truncated); err == nil {
+		t.Error("expected an error for a truncated code, got nil")
+	}
+}
+
+func TestDecodeShareCode_InvalidBase64(t *testing.T) {
+	if _, err := DecodeShareCode("not valid base64url!!!"); err == nil {
+		t.Error("expected an error for invalid base64, got nil")
+	}
+}
+
+func TestDecodeShareCode_EmptyString(t *testing.T) {
+	if _, err := DecodeShareCode(""); err == nil {
+		t.Error("expected an error for an empty code, got nil")
+	}
+}
+
+func TestDecodeShareCode_UnknownVersion(t *testing.T) {
+	// Build a minimal valid-shape payload but with a bogus version byte, and
+	// a correct checksum so only the version check can reject it.
+	payload := []byte{99, 16, 0, 0, 0, 0, 0, 0, 0, 0}
+	payload = append(payload, checksum(payload))
+	code := base64.RawURLEncoding.EncodeToString(payload)
+
+	if _, err := DecodeShareCode(code); err == nil {
+		t.Error("expected an error for an unknown format version, got nil")
+	}
+}
+
+func TestDecodeShareCode_TargetBotIdOutOfRange(t *testing.T) {
+	// version=1, size=16, 0 vWalls, 0 hWalls, 0 targets, targetBotId=7 (invalid)
+	payload := []byte{1, 16, 0, 0, 0, 7}
+	payload = append(payload, checksum(payload))
+	code := base64.RawURLEncoding.EncodeToString(payload)
+
+	if _, err := DecodeShareCode(code); err == nil {
+		t.Error("expected an error for an out-of-range target bot id, got nil")
+	}
+}
+
+func TestEncodeShareCode_RejectsOutOfRangePosition(t *testing.T) {
+	board := NewBoardWithTargets(20, nil, nil, []Position{{X: 19, Y: 19}})
+	bots := map[BotId]Position{0: {X: 0, Y: 0}, 1: {X: 1, Y: 0}, 2: {X: 2, Y: 0}, 3: {X: 3, Y: 0}}
+	game := &Game{Board: board, Bots: bots, Target: BotPosition{Id: 0, Pos: Position{X: 19, Y: 19}}}
+
+	if _, err := EncodeShareCode(game); err == nil {
+		t.Error("expected an error encoding a board with coordinates >15, got nil")
+	}
+}

--- a/planning/BOARD_SHARING_DESIGN.md
+++ b/planning/BOARD_SHARING_DESIGN.md
@@ -1,0 +1,226 @@
+# Board Sharing Design
+
+## Overview
+
+Let a player share a specific board they've found interesting — via a URL or a
+QR code — so someone else (or themselves, later) can jump straight into solo
+play on that exact board: same walls, same starting robot positions, same
+target.
+
+## Goals
+
+1. **Shareable**: a URL that works when pasted into text/chat/email, and a QR
+   code that works when scanned on a phone, both leading to the same place.
+2. **Durable**: unlike a normal room (garbage-collected after 24h of
+   inactivity), a share link should keep working indefinitely — it's meant to
+   be bookmarked ("save it for future me"), not just passed around in the
+   moment.
+3. **Transparent**: the URL encodes the full board state directly. No
+   server-side lookup table, no expiring IDs. Anyone who understands the
+   format can hand-construct one — this is intentionally a small step toward
+   a future board editor, whose "export" step would produce exactly this kind
+   of link.
+4. **Available anywhere**: from solo play or a multiplayer room, since the
+   thing being shared (the board) is independent of who's playing it or how
+   many players there are.
+
+## Design decisions (from discussion)
+
+- **Landing experience**: opening a share link creates a real solo `Room`
+  server-side (not a lightweight, Daily-Challenge-style client-only view).
+  The recipient gets the full normal experience — BBot solver comparison,
+  room settings, continuing into a new random puzzle afterward via the
+  existing "Next Puzzle" flow.
+- **Snapshot state**: a share link always captures the board's fresh,
+  round-start state — wall layout, original robot positions, target — never
+  wherever the sharer's own robots happen to be mid-solve. This falls out for
+  free: `Room.CurrentGame` is never mutated by player moves during a round
+  (see below), so there's nothing to "reset" before encoding.
+- **Encoding scope**: the raw wall/target layout is encoded directly (see
+  below), not which of the 12 canonical panels produced it — so this covers
+  any board shape from day one, including whatever a future board editor
+  might produce, with no separate v2 format needed later.
+- **Where "Share" appears**: any active game, solo or multiplayer. Since the
+  underlying data (`Room.CurrentGame`) has the same shape either way, this
+  costs nothing extra to support.
+
+## Why this is simpler than it first looks
+
+`Room.CurrentGame` is already the "fresh" state, always. Player moves during
+a round are client-side only; `SubmitSolution` records a solution's move
+list without mutating `room.CurrentGame.Bots`. The board only actually
+changes at the *start* of the next round (`GameLifecycle.NewGameSource`/
+`CommitNewGame`, added for the min-solution-length feature). So "the
+original puzzle" and "what the server currently has recorded" are the same
+thing, for the whole round, in both solo and multiplayer rooms — there's
+nothing to reconstruct or reset before encoding.
+
+That means the entire feature is: encode the board's walls/targets + 4 robot
+positions + 1 target into a token, and a new endpoint that turns a token back
+into a `*model.Game` (via the existing `model.NewBoardWithTargets` +
+`model.NewGame`, both already used for exactly this kind of reconstruction —
+see `NewBoardFromProto`) and commits it as a brand-new room's current game —
+reusing `CommitNewGame`, which already exists for exactly this "here's the
+game, make it the room's current one" job.
+
+## Encoding format (v1)
+
+Encodes the raw wall/target data directly (`Board.VWalls()`/`HWalls()`/
+`PossibleTargets()`, all already exposed on the `Board` interface and, as of
+the persistence bug fix earlier, already on the proto `Board` message too) —
+not which panels produced it. This works for *any* board shape, not just
+combinations of the 12 canonical panels, so there's no v1/v2 split and no
+extra plumbing needed to recover "which panels was this built from" (which
+isn't tracked anywhere today).
+
+A count-prefixed sparse list per field, one byte per position (x and y each
+fit a nibble, since the board is 16×16 → 0-15):
+
+| Bytes | Field | Notes |
+|---|---|---|
+| 0 | Format version | `1` |
+| 1 | Board size | `16` today; encoded rather than assumed |
+| 2 | vWall count (N1) | |
+| 3..3+N1-1 | vWall positions | 1 byte each, `(x<<4)\|y` |
+| next 1 | hWall count (N2) | |
+| next N2 | hWall positions | 1 byte each |
+| next 1 | Possible-target count (N3) | |
+| next N3 | Possible-target positions | 1 byte each |
+| next 1 | Target bot ID | 0-3 |
+| next 1 | Target position | packed |
+| next 4 | Bot 0-3 positions | 1 byte each, packed |
+| last 1 | Checksum | sum of all preceding bytes, mod 256 |
+
+For a typical board (25 vWalls, 25 hWalls, 17 possible targets — checked
+against a real generated board), that's 12 + 25 + 25 + 17 = **79 bytes**,
+base64url-encoded (RFC 4648 §5, no padding) → **~106 characters**. Longer
+than a hypothetical panel-only encoding (~23 characters), but sparse lists
+still beat a dense presence-bitmask for this data (walls/targets occupy only
+~7-10% of their possible slots — a fixed bitmask covering every possible slot
+would run ~92-96 bytes). ~106 characters is still trivially fine for a URL
+path segment, an SMS, or a QR code, with no percent-encoding needed.
+
+The checksum is defense against a mistyped/truncated link (unlikely for a
+scanned QR code, more plausible for a hand-copied URL) producing a
+*different but still structurally valid* board instead of an obvious error.
+
+Decoding validates: version and board size are known/sane, all positions are
+in bounds, and the resulting board/bots/target pass `model.NewGame`'s
+existing validation (no overlapping bots, target bot ID matches a real bot)
+— this is the same validation every other game already goes through, just
+reached from a new, less-trusted input source (a client-constructed token,
+rather than server-generated data). Any failure is a decode error, not a
+panic.
+
+Both Go (`model`) and TypeScript (client) need an implementation of this
+encode/decode scheme, since creating a link is done client-side (the client
+already has the full board in `room.value.currentGame`, so no server round
+trip is needed just to *generate* a link) while consuming one is server-side
+(a new endpoint reconstructs and validates the game). These two
+implementations need to agree exactly — worth a handful of shared fixed test
+vectors (same input bytes/fields, checked against the same expected token in
+both `model`'s tests and the client's).
+
+## Architecture
+
+### 1. Creating a link (client-side, no server call)
+
+- New `shareCode.ts` (client) with `encode(game: Game): string` mirroring the
+  format above, reading directly from `room.value.currentGame`.
+- New Share button placed in the "GAME N" title row (`GameBoard.vue`'s
+  `.title`, an `<h1>` that already spans the board's own grid column and
+  isn't gated behind `!gameEnded` — a single, state-independent location
+  needing no separate post-game placement). Positioned to the right of the
+  "GAME N" text, pinned to that row's right edge so it lines up with the
+  board's own right edge at any screen width. Blue icon-only button, white
+  three-dot share glyph.
+  - Implementation note: `.title` currently centers "GAME N" via
+    `text-align: center` on the `<h1>` itself. The button must be taken out
+    of that text flow (`.title` gets `position: relative`, the button gets
+    `position: absolute; right: 0` and vertical centering) rather than added
+    as a plain third inline child — otherwise the centering would center the
+    text+button as a group and visibly shift "GAME N" off the board's true
+    center.
+- New `ShareModal.vue` (Teleport-based, matching `SettingsModal.vue`'s
+  `.modal-backdrop`/`.modal` pattern), titled "Share Board": a QR code of the
+  share URL in a white box (needed for scan reliability regardless of the
+  app's dark/light theme), then a "Copy Link" button below it — both
+  represent the same URL, and the URL itself is never shown as text (it's
+  an opaque-looking token with nothing meaningful to read at a glance).
+  QR generation is client-side only (a small library rendering to
+  canvas/SVG from the URL string) — no server involvement for either half of
+  link creation.
+  - Reuses the existing clipboard-copy pattern from `RoomView.vue`'s
+    `copyShareUrl` (`navigator.clipboard.writeText` with an
+    `execCommand('copy')` fallback for older browsers) and its exact "Copy
+    Link" label — but copies the constructed `/share/:code` URL, not
+    `window.location.href` (the current page), since the share link is a
+    different URL than the room being viewed.
+  - Unlike the existing `copyShareUrl` button (which gives no feedback on
+    click), this one swaps its label to "Copied!" for ~1.5s after a
+    successful copy, then reverts.
+
+### 2. Consuming a link (new route + new RPC)
+
+- New route `/share/:code` (`router.ts`) → new `ShareLandingView.vue`.
+- On mount: call a new RPC, e.g. `CreateRoomFromSharedBoard(player_name,
+  encoded_board)`, mirroring today's solo-play bootstrap
+  (`HomeView.vue`'s `startSoloGame`) — no name prompt, same default/saved
+  player name behavior — then `router.push` to `/room/:newRoomId`, same as
+  normal solo play.
+- On decode/validation failure, show a simple error state ("This link looks
+  broken or came from a newer version of BounceBot") with a way back to Home,
+  rather than a silent redirect or crash.
+
+### 3. Server (`server/room`, `model`)
+
+- New `model/share_code.go`: `EncodeShareCode(game *Game) (string, error)` /
+  `DecodeShareCode(code string) (*Game, error)`, implementing the format
+  above and its validation.
+- New `RoomService` method, e.g. `CreateRoomFromBoard(playerName string, game
+  *model.Game) (*Room, string, string, error)`: creates a room the same way
+  `Create` does today, then commits the given game directly via the existing
+  `GameLifecycle.CommitNewGame(room, game)` — **reused as-is**, no new
+  board-selection logic needed, since the board is already fully determined.
+  Note this deliberately bypasses `MinSolutionLength`/`generateBoard`'s retry
+  loop entirely: there's no "board" to search for or reject, it's fully
+  specified by the link.
+- Still fires the normal post-commit `onGameStart` hook, so the recipient
+  gets the same BBot solver comparison as any other round.
+- New RPC `CreateRoomFromSharedBoard` in `bouncebot.proto`, handled in
+  `bouncebotserver.go`: decode + validate the token, call
+  `RoomService.CreateRoomFromBoard`, return the same shape as
+  `CreateRoomResponse` (room, player_id, session_token) so the client can
+  reuse existing post-creation logic.
+
+## Error handling
+
+- **Malformed/corrupted token** (bad checksum, wrong version, out-of-range
+  position, fails `model.NewGame` validation): RPC returns `InvalidArgument`;
+  client shows a friendly "this link looks broken" state.
+- **Unknown format version** (a link from a future version of the app):
+  treated the same as malformed for now — no forward-compatible partial
+  decoding in v1.
+
+## Future considerations (post-v1)
+
+- **Board editor**: place walls/robots/target freely, "export" as a share
+  link. The v1 format already encodes arbitrary wall/target layouts, so no
+  new format version should be needed for this — just a UI to produce one.
+- **"Beat my score"**: optionally embed the sharer's move count in the link
+  or in accompanying share text, shown to the recipient as a target to beat.
+- **Social link previews**: Open Graph tags for a nice preview card when
+  pasted into Slack/iMessage/etc. Needs some form of server-rendered meta
+  tags for an otherwise pure client-side SPA — out of scope for v1.
+
+## Work breakdown
+
+1. **`model/share_code.go`**: encode/decode + validation, with unit tests
+   including the shared fixed-vector round-trip cases.
+2. **Server**: `RoomService.CreateRoomFromBoard`, `CreateRoomFromSharedBoard`
+   RPC + proto changes, `bouncebotserver.go` handler.
+3. **Client encode + Share UI**: `shareCode.ts`, `ShareModal.vue`, Share
+   button wiring in `RoomView.vue`.
+4. **Client landing route**: `/share/:code` route, `ShareLandingView.vue`.
+5. **QR generation**: pick a small client-side library, wire into
+   `ShareModal.vue`.

--- a/proto/bouncebot.pb.go
+++ b/proto/bouncebot.pb.go
@@ -706,6 +706,61 @@ func (x *CreateRoomRequest) GetIsSinglePlayer() bool {
 	return false
 }
 
+// Creates a new single-player room seeded with a specific board, decoded
+// from a share code (see planning/BOARD_SHARING_DESIGN.md). Returns the same
+// shape as CreateRoomResponse.
+type CreateRoomFromSharedBoardRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PlayerName    string                 `protobuf:"bytes,1,opt,name=player_name,json=playerName,proto3" json:"player_name,omitempty"`
+	ShareCode     string                 `protobuf:"bytes,2,opt,name=share_code,json=shareCode,proto3" json:"share_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateRoomFromSharedBoardRequest) Reset() {
+	*x = CreateRoomFromSharedBoardRequest{}
+	mi := &file_bouncebot_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateRoomFromSharedBoardRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateRoomFromSharedBoardRequest) ProtoMessage() {}
+
+func (x *CreateRoomFromSharedBoardRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bouncebot_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateRoomFromSharedBoardRequest.ProtoReflect.Descriptor instead.
+func (*CreateRoomFromSharedBoardRequest) Descriptor() ([]byte, []int) {
+	return file_bouncebot_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CreateRoomFromSharedBoardRequest) GetPlayerName() string {
+	if x != nil {
+		return x.PlayerName
+	}
+	return ""
+}
+
+func (x *CreateRoomFromSharedBoardRequest) GetShareCode() string {
+	if x != nil {
+		return x.ShareCode
+	}
+	return ""
+}
+
 type JoinRoomRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RoomId        string                 `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
@@ -716,7 +771,7 @@ type JoinRoomRequest struct {
 
 func (x *JoinRoomRequest) Reset() {
 	*x = JoinRoomRequest{}
-	mi := &file_bouncebot_proto_msgTypes[10]
+	mi := &file_bouncebot_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -728,7 +783,7 @@ func (x *JoinRoomRequest) String() string {
 func (*JoinRoomRequest) ProtoMessage() {}
 
 func (x *JoinRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[10]
+	mi := &file_bouncebot_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -741,7 +796,7 @@ func (x *JoinRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRoomRequest.ProtoReflect.Descriptor instead.
 func (*JoinRoomRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{10}
+	return file_bouncebot_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *JoinRoomRequest) GetRoomId() string {
@@ -769,7 +824,7 @@ type JoinRoomResponse struct {
 
 func (x *JoinRoomResponse) Reset() {
 	*x = JoinRoomResponse{}
-	mi := &file_bouncebot_proto_msgTypes[11]
+	mi := &file_bouncebot_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -781,7 +836,7 @@ func (x *JoinRoomResponse) String() string {
 func (*JoinRoomResponse) ProtoMessage() {}
 
 func (x *JoinRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[11]
+	mi := &file_bouncebot_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -794,7 +849,7 @@ func (x *JoinRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRoomResponse.ProtoReflect.Descriptor instead.
 func (*JoinRoomResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{11}
+	return file_bouncebot_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *JoinRoomResponse) GetRoom() *Room {
@@ -829,7 +884,7 @@ type CreateRoomResponse struct {
 
 func (x *CreateRoomResponse) Reset() {
 	*x = CreateRoomResponse{}
-	mi := &file_bouncebot_proto_msgTypes[12]
+	mi := &file_bouncebot_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -841,7 +896,7 @@ func (x *CreateRoomResponse) String() string {
 func (*CreateRoomResponse) ProtoMessage() {}
 
 func (x *CreateRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[12]
+	mi := &file_bouncebot_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -854,7 +909,7 @@ func (x *CreateRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoomResponse.ProtoReflect.Descriptor instead.
 func (*CreateRoomResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{12}
+	return file_bouncebot_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CreateRoomResponse) GetRoom() *Room {
@@ -887,7 +942,7 @@ type GetRoomRequest struct {
 
 func (x *GetRoomRequest) Reset() {
 	*x = GetRoomRequest{}
-	mi := &file_bouncebot_proto_msgTypes[13]
+	mi := &file_bouncebot_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -899,7 +954,7 @@ func (x *GetRoomRequest) String() string {
 func (*GetRoomRequest) ProtoMessage() {}
 
 func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[13]
+	mi := &file_bouncebot_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -912,7 +967,7 @@ func (x *GetRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoomRequest.ProtoReflect.Descriptor instead.
 func (*GetRoomRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{13}
+	return file_bouncebot_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetRoomRequest) GetRoomId() string {
@@ -931,7 +986,7 @@ type StartGameRequest struct {
 
 func (x *StartGameRequest) Reset() {
 	*x = StartGameRequest{}
-	mi := &file_bouncebot_proto_msgTypes[14]
+	mi := &file_bouncebot_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -943,7 +998,7 @@ func (x *StartGameRequest) String() string {
 func (*StartGameRequest) ProtoMessage() {}
 
 func (x *StartGameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[14]
+	mi := &file_bouncebot_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -956,7 +1011,7 @@ func (x *StartGameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartGameRequest.ProtoReflect.Descriptor instead.
 func (*StartGameRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{14}
+	return file_bouncebot_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *StartGameRequest) GetRoomId() string {
@@ -977,7 +1032,7 @@ type SubmitSolutionRequest struct {
 
 func (x *SubmitSolutionRequest) Reset() {
 	*x = SubmitSolutionRequest{}
-	mi := &file_bouncebot_proto_msgTypes[15]
+	mi := &file_bouncebot_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -989,7 +1044,7 @@ func (x *SubmitSolutionRequest) String() string {
 func (*SubmitSolutionRequest) ProtoMessage() {}
 
 func (x *SubmitSolutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[15]
+	mi := &file_bouncebot_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1002,7 +1057,7 @@ func (x *SubmitSolutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitSolutionRequest.ProtoReflect.Descriptor instead.
 func (*SubmitSolutionRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{15}
+	return file_bouncebot_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SubmitSolutionRequest) GetRoomId() string {
@@ -1035,7 +1090,7 @@ type SubmitSolutionResponse struct {
 
 func (x *SubmitSolutionResponse) Reset() {
 	*x = SubmitSolutionResponse{}
-	mi := &file_bouncebot_proto_msgTypes[16]
+	mi := &file_bouncebot_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1047,7 +1102,7 @@ func (x *SubmitSolutionResponse) String() string {
 func (*SubmitSolutionResponse) ProtoMessage() {}
 
 func (x *SubmitSolutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[16]
+	mi := &file_bouncebot_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1060,7 +1115,7 @@ func (x *SubmitSolutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitSolutionResponse.ProtoReflect.Descriptor instead.
 func (*SubmitSolutionResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{16}
+	return file_bouncebot_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SubmitSolutionResponse) GetSolution() *PlayerSolution {
@@ -1080,7 +1135,7 @@ type MarkFinishedSolvingRequest struct {
 
 func (x *MarkFinishedSolvingRequest) Reset() {
 	*x = MarkFinishedSolvingRequest{}
-	mi := &file_bouncebot_proto_msgTypes[17]
+	mi := &file_bouncebot_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1092,7 +1147,7 @@ func (x *MarkFinishedSolvingRequest) String() string {
 func (*MarkFinishedSolvingRequest) ProtoMessage() {}
 
 func (x *MarkFinishedSolvingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[17]
+	mi := &file_bouncebot_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1105,7 +1160,7 @@ func (x *MarkFinishedSolvingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MarkFinishedSolvingRequest.ProtoReflect.Descriptor instead.
 func (*MarkFinishedSolvingRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{17}
+	return file_bouncebot_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *MarkFinishedSolvingRequest) GetRoomId() string {
@@ -1131,7 +1186,7 @@ type MarkFinishedSolvingResponse struct {
 
 func (x *MarkFinishedSolvingResponse) Reset() {
 	*x = MarkFinishedSolvingResponse{}
-	mi := &file_bouncebot_proto_msgTypes[18]
+	mi := &file_bouncebot_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1143,7 +1198,7 @@ func (x *MarkFinishedSolvingResponse) String() string {
 func (*MarkFinishedSolvingResponse) ProtoMessage() {}
 
 func (x *MarkFinishedSolvingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[18]
+	mi := &file_bouncebot_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1156,7 +1211,7 @@ func (x *MarkFinishedSolvingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MarkFinishedSolvingResponse.ProtoReflect.Descriptor instead.
 func (*MarkFinishedSolvingResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{18}
+	return file_bouncebot_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *MarkFinishedSolvingResponse) GetSuccess() bool {
@@ -1176,7 +1231,7 @@ type MarkReadyForNextRequest struct {
 
 func (x *MarkReadyForNextRequest) Reset() {
 	*x = MarkReadyForNextRequest{}
-	mi := &file_bouncebot_proto_msgTypes[19]
+	mi := &file_bouncebot_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1188,7 +1243,7 @@ func (x *MarkReadyForNextRequest) String() string {
 func (*MarkReadyForNextRequest) ProtoMessage() {}
 
 func (x *MarkReadyForNextRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[19]
+	mi := &file_bouncebot_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1201,7 +1256,7 @@ func (x *MarkReadyForNextRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MarkReadyForNextRequest.ProtoReflect.Descriptor instead.
 func (*MarkReadyForNextRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{19}
+	return file_bouncebot_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *MarkReadyForNextRequest) GetRoomId() string {
@@ -1227,7 +1282,7 @@ type MarkReadyForNextResponse struct {
 
 func (x *MarkReadyForNextResponse) Reset() {
 	*x = MarkReadyForNextResponse{}
-	mi := &file_bouncebot_proto_msgTypes[20]
+	mi := &file_bouncebot_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1239,7 +1294,7 @@ func (x *MarkReadyForNextResponse) String() string {
 func (*MarkReadyForNextResponse) ProtoMessage() {}
 
 func (x *MarkReadyForNextResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[20]
+	mi := &file_bouncebot_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1252,7 +1307,7 @@ func (x *MarkReadyForNextResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MarkReadyForNextResponse.ProtoReflect.Descriptor instead.
 func (*MarkReadyForNextResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{20}
+	return file_bouncebot_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *MarkReadyForNextResponse) GetSuccess() bool {
@@ -1275,7 +1330,7 @@ type SolverResult struct {
 
 func (x *SolverResult) Reset() {
 	*x = SolverResult{}
-	mi := &file_bouncebot_proto_msgTypes[21]
+	mi := &file_bouncebot_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1287,7 +1342,7 @@ func (x *SolverResult) String() string {
 func (*SolverResult) ProtoMessage() {}
 
 func (x *SolverResult) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[21]
+	mi := &file_bouncebot_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1300,7 +1355,7 @@ func (x *SolverResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SolverResult.ProtoReflect.Descriptor instead.
 func (*SolverResult) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{21}
+	return file_bouncebot_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SolverResult) GetSolverName() string {
@@ -1342,7 +1397,7 @@ type UpdateRoomSettingsRequest struct {
 
 func (x *UpdateRoomSettingsRequest) Reset() {
 	*x = UpdateRoomSettingsRequest{}
-	mi := &file_bouncebot_proto_msgTypes[22]
+	mi := &file_bouncebot_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1354,7 +1409,7 @@ func (x *UpdateRoomSettingsRequest) String() string {
 func (*UpdateRoomSettingsRequest) ProtoMessage() {}
 
 func (x *UpdateRoomSettingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[22]
+	mi := &file_bouncebot_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1367,7 +1422,7 @@ func (x *UpdateRoomSettingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoomSettingsRequest.ProtoReflect.Descriptor instead.
 func (*UpdateRoomSettingsRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{22}
+	return file_bouncebot_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *UpdateRoomSettingsRequest) GetRoomId() string {
@@ -1401,7 +1456,7 @@ type UpdateRoomSettingsResponse struct {
 
 func (x *UpdateRoomSettingsResponse) Reset() {
 	*x = UpdateRoomSettingsResponse{}
-	mi := &file_bouncebot_proto_msgTypes[23]
+	mi := &file_bouncebot_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1413,7 +1468,7 @@ func (x *UpdateRoomSettingsResponse) String() string {
 func (*UpdateRoomSettingsResponse) ProtoMessage() {}
 
 func (x *UpdateRoomSettingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[23]
+	mi := &file_bouncebot_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1426,7 +1481,7 @@ func (x *UpdateRoomSettingsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoomSettingsResponse.ProtoReflect.Descriptor instead.
 func (*UpdateRoomSettingsResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{23}
+	return file_bouncebot_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *UpdateRoomSettingsResponse) GetSuccess() bool {
@@ -1454,7 +1509,7 @@ type BootPlayerRequest struct {
 
 func (x *BootPlayerRequest) Reset() {
 	*x = BootPlayerRequest{}
-	mi := &file_bouncebot_proto_msgTypes[24]
+	mi := &file_bouncebot_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1466,7 +1521,7 @@ func (x *BootPlayerRequest) String() string {
 func (*BootPlayerRequest) ProtoMessage() {}
 
 func (x *BootPlayerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[24]
+	mi := &file_bouncebot_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1479,7 +1534,7 @@ func (x *BootPlayerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootPlayerRequest.ProtoReflect.Descriptor instead.
 func (*BootPlayerRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{24}
+	return file_bouncebot_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *BootPlayerRequest) GetRoomId() string {
@@ -1513,7 +1568,7 @@ type BootPlayerResponse struct {
 
 func (x *BootPlayerResponse) Reset() {
 	*x = BootPlayerResponse{}
-	mi := &file_bouncebot_proto_msgTypes[25]
+	mi := &file_bouncebot_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1525,7 +1580,7 @@ func (x *BootPlayerResponse) String() string {
 func (*BootPlayerResponse) ProtoMessage() {}
 
 func (x *BootPlayerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[25]
+	mi := &file_bouncebot_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1538,7 +1593,7 @@ func (x *BootPlayerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootPlayerResponse.ProtoReflect.Descriptor instead.
 func (*BootPlayerResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{25}
+	return file_bouncebot_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *BootPlayerResponse) GetSuccess() bool {
@@ -1565,7 +1620,7 @@ type LeaveRoomRequest struct {
 
 func (x *LeaveRoomRequest) Reset() {
 	*x = LeaveRoomRequest{}
-	mi := &file_bouncebot_proto_msgTypes[26]
+	mi := &file_bouncebot_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1577,7 +1632,7 @@ func (x *LeaveRoomRequest) String() string {
 func (*LeaveRoomRequest) ProtoMessage() {}
 
 func (x *LeaveRoomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[26]
+	mi := &file_bouncebot_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1590,7 +1645,7 @@ func (x *LeaveRoomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveRoomRequest.ProtoReflect.Descriptor instead.
 func (*LeaveRoomRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{26}
+	return file_bouncebot_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LeaveRoomRequest) GetRoomId() string {
@@ -1616,7 +1671,7 @@ type LeaveRoomResponse struct {
 
 func (x *LeaveRoomResponse) Reset() {
 	*x = LeaveRoomResponse{}
-	mi := &file_bouncebot_proto_msgTypes[27]
+	mi := &file_bouncebot_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1628,7 +1683,7 @@ func (x *LeaveRoomResponse) String() string {
 func (*LeaveRoomResponse) ProtoMessage() {}
 
 func (x *LeaveRoomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[27]
+	mi := &file_bouncebot_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1641,7 +1696,7 @@ func (x *LeaveRoomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveRoomResponse.ProtoReflect.Descriptor instead.
 func (*LeaveRoomResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{27}
+	return file_bouncebot_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LeaveRoomResponse) GetSuccess() bool {
@@ -1664,7 +1719,7 @@ type DailyPuzzleInfo struct {
 
 func (x *DailyPuzzleInfo) Reset() {
 	*x = DailyPuzzleInfo{}
-	mi := &file_bouncebot_proto_msgTypes[28]
+	mi := &file_bouncebot_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1676,7 +1731,7 @@ func (x *DailyPuzzleInfo) String() string {
 func (*DailyPuzzleInfo) ProtoMessage() {}
 
 func (x *DailyPuzzleInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[28]
+	mi := &file_bouncebot_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1689,7 +1744,7 @@ func (x *DailyPuzzleInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DailyPuzzleInfo.ProtoReflect.Descriptor instead.
 func (*DailyPuzzleInfo) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{28}
+	return file_bouncebot_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *DailyPuzzleInfo) GetDifficulty() string {
@@ -1730,7 +1785,7 @@ type GetDailyChallengeRequest struct {
 
 func (x *GetDailyChallengeRequest) Reset() {
 	*x = GetDailyChallengeRequest{}
-	mi := &file_bouncebot_proto_msgTypes[29]
+	mi := &file_bouncebot_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +1797,7 @@ func (x *GetDailyChallengeRequest) String() string {
 func (*GetDailyChallengeRequest) ProtoMessage() {}
 
 func (x *GetDailyChallengeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[29]
+	mi := &file_bouncebot_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +1810,7 @@ func (x *GetDailyChallengeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDailyChallengeRequest.ProtoReflect.Descriptor instead.
 func (*GetDailyChallengeRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{29}
+	return file_bouncebot_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetDailyChallengeRequest) GetPlayerId() string {
@@ -1783,7 +1838,7 @@ type GetDailyChallengeResponse struct {
 
 func (x *GetDailyChallengeResponse) Reset() {
 	*x = GetDailyChallengeResponse{}
-	mi := &file_bouncebot_proto_msgTypes[30]
+	mi := &file_bouncebot_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1795,7 +1850,7 @@ func (x *GetDailyChallengeResponse) String() string {
 func (*GetDailyChallengeResponse) ProtoMessage() {}
 
 func (x *GetDailyChallengeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[30]
+	mi := &file_bouncebot_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1808,7 +1863,7 @@ func (x *GetDailyChallengeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDailyChallengeResponse.ProtoReflect.Descriptor instead.
 func (*GetDailyChallengeResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{30}
+	return file_bouncebot_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetDailyChallengeResponse) GetDate() string {
@@ -1844,7 +1899,7 @@ type SubmitDailySolutionRequest struct {
 
 func (x *SubmitDailySolutionRequest) Reset() {
 	*x = SubmitDailySolutionRequest{}
-	mi := &file_bouncebot_proto_msgTypes[31]
+	mi := &file_bouncebot_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1856,7 +1911,7 @@ func (x *SubmitDailySolutionRequest) String() string {
 func (*SubmitDailySolutionRequest) ProtoMessage() {}
 
 func (x *SubmitDailySolutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[31]
+	mi := &file_bouncebot_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1869,7 +1924,7 @@ func (x *SubmitDailySolutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitDailySolutionRequest.ProtoReflect.Descriptor instead.
 func (*SubmitDailySolutionRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{31}
+	return file_bouncebot_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SubmitDailySolutionRequest) GetPlayerId() string {
@@ -1910,7 +1965,7 @@ type SubmitDailySolutionResponse struct {
 
 func (x *SubmitDailySolutionResponse) Reset() {
 	*x = SubmitDailySolutionResponse{}
-	mi := &file_bouncebot_proto_msgTypes[32]
+	mi := &file_bouncebot_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1922,7 +1977,7 @@ func (x *SubmitDailySolutionResponse) String() string {
 func (*SubmitDailySolutionResponse) ProtoMessage() {}
 
 func (x *SubmitDailySolutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[32]
+	mi := &file_bouncebot_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1935,7 +1990,7 @@ func (x *SubmitDailySolutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitDailySolutionResponse.ProtoReflect.Descriptor instead.
 func (*SubmitDailySolutionResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{32}
+	return file_bouncebot_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SubmitDailySolutionResponse) GetCorrect() bool {
@@ -1960,7 +2015,7 @@ type GetServerInfoRequest struct {
 
 func (x *GetServerInfoRequest) Reset() {
 	*x = GetServerInfoRequest{}
-	mi := &file_bouncebot_proto_msgTypes[33]
+	mi := &file_bouncebot_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1972,7 +2027,7 @@ func (x *GetServerInfoRequest) String() string {
 func (*GetServerInfoRequest) ProtoMessage() {}
 
 func (x *GetServerInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[33]
+	mi := &file_bouncebot_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1985,7 +2040,7 @@ func (x *GetServerInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServerInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetServerInfoRequest) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{33}
+	return file_bouncebot_proto_rawDescGZIP(), []int{34}
 }
 
 type GetServerInfoResponse struct {
@@ -1997,7 +2052,7 @@ type GetServerInfoResponse struct {
 
 func (x *GetServerInfoResponse) Reset() {
 	*x = GetServerInfoResponse{}
-	mi := &file_bouncebot_proto_msgTypes[34]
+	mi := &file_bouncebot_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2009,7 +2064,7 @@ func (x *GetServerInfoResponse) String() string {
 func (*GetServerInfoResponse) ProtoMessage() {}
 
 func (x *GetServerInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bouncebot_proto_msgTypes[34]
+	mi := &file_bouncebot_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2022,7 +2077,7 @@ func (x *GetServerInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetServerInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetServerInfoResponse) Descriptor() ([]byte, []int) {
-	return file_bouncebot_proto_rawDescGZIP(), []int{34}
+	return file_bouncebot_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetServerInfoResponse) GetDailyChallengeEnabled() bool {
@@ -2088,7 +2143,12 @@ const file_bouncebot_proto_rawDesc = "" +
 	"\x11CreateRoomRequest\x12\x1f\n" +
 	"\vplayer_name\x18\x01 \x01(\tR\n" +
 	"playerName\x12(\n" +
-	"\x10is_single_player\x18\x02 \x01(\bR\x0eisSinglePlayer\"K\n" +
+	"\x10is_single_player\x18\x02 \x01(\bR\x0eisSinglePlayer\"b\n" +
+	" CreateRoomFromSharedBoardRequest\x12\x1f\n" +
+	"\vplayer_name\x18\x01 \x01(\tR\n" +
+	"playerName\x12\x1d\n" +
+	"\n" +
+	"share_code\x18\x02 \x01(\tR\tshareCode\"K\n" +
 	"\x0fJoinRoomRequest\x12\x17\n" +
 	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12\x1f\n" +
 	"\vplayer_name\x18\x02 \x01(\tR\n" +
@@ -2172,7 +2232,7 @@ const file_bouncebot_proto_rawDesc = "" +
 	"\x0enew_completion\x18\x02 \x01(\bR\rnewCompletion\"\x16\n" +
 	"\x14GetServerInfoRequest\"O\n" +
 	"\x15GetServerInfoResponse\x126\n" +
-	"\x17daily_challenge_enabled\x18\x01 \x01(\bR\x15dailyChallengeEnabled2\xd1\b\n" +
+	"\x17daily_challenge_enabled\x18\x01 \x01(\bR\x15dailyChallengeEnabled2\xbc\t\n" +
 	"\tBounceBot\x12K\n" +
 	"\n" +
 	"CreateRoom\x12\x1c.bouncebot.CreateRoomRequest\x1a\x1d.bouncebot.CreateRoomResponse\"\x00\x12E\n" +
@@ -2185,7 +2245,8 @@ const file_bouncebot_proto_rawDesc = "" +
 	"\x12UpdateRoomSettings\x12$.bouncebot.UpdateRoomSettingsRequest\x1a%.bouncebot.UpdateRoomSettingsResponse\"\x00\x12K\n" +
 	"\n" +
 	"BootPlayer\x12\x1c.bouncebot.BootPlayerRequest\x1a\x1d.bouncebot.BootPlayerResponse\"\x00\x12H\n" +
-	"\tLeaveRoom\x12\x1b.bouncebot.LeaveRoomRequest\x1a\x1c.bouncebot.LeaveRoomResponse\"\x00\x12`\n" +
+	"\tLeaveRoom\x12\x1b.bouncebot.LeaveRoomRequest\x1a\x1c.bouncebot.LeaveRoomResponse\"\x00\x12i\n" +
+	"\x19CreateRoomFromSharedBoard\x12+.bouncebot.CreateRoomFromSharedBoardRequest\x1a\x1d.bouncebot.CreateRoomResponse\"\x00\x12`\n" +
 	"\x11GetDailyChallenge\x12#.bouncebot.GetDailyChallengeRequest\x1a$.bouncebot.GetDailyChallengeResponse\"\x00\x12f\n" +
 	"\x13SubmitDailySolution\x12%.bouncebot.SubmitDailySolutionRequest\x1a&.bouncebot.SubmitDailySolutionResponse\"\x00\x12T\n" +
 	"\rGetServerInfo\x12\x1f.bouncebot.GetServerInfoRequest\x1a .bouncebot.GetServerInfoResponse\"\x00B(Z&github.com/srsalisbury/bouncebot/protob\x06proto3"
@@ -2202,44 +2263,45 @@ func file_bouncebot_proto_rawDescGZIP() []byte {
 	return file_bouncebot_proto_rawDescData
 }
 
-var file_bouncebot_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_bouncebot_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_bouncebot_proto_goTypes = []any{
-	(*Position)(nil),                    // 0: bouncebot.Position
-	(*Board)(nil),                       // 1: bouncebot.Board
-	(*BotPos)(nil),                      // 2: bouncebot.BotPos
-	(*Game)(nil),                        // 3: bouncebot.Game
-	(*Player)(nil),                      // 4: bouncebot.Player
-	(*PlayerSolution)(nil),              // 5: bouncebot.PlayerSolution
-	(*PlayerScore)(nil),                 // 6: bouncebot.PlayerScore
-	(*RoomSettings)(nil),                // 7: bouncebot.RoomSettings
-	(*Room)(nil),                        // 8: bouncebot.Room
-	(*CreateRoomRequest)(nil),           // 9: bouncebot.CreateRoomRequest
-	(*JoinRoomRequest)(nil),             // 10: bouncebot.JoinRoomRequest
-	(*JoinRoomResponse)(nil),            // 11: bouncebot.JoinRoomResponse
-	(*CreateRoomResponse)(nil),          // 12: bouncebot.CreateRoomResponse
-	(*GetRoomRequest)(nil),              // 13: bouncebot.GetRoomRequest
-	(*StartGameRequest)(nil),            // 14: bouncebot.StartGameRequest
-	(*SubmitSolutionRequest)(nil),       // 15: bouncebot.SubmitSolutionRequest
-	(*SubmitSolutionResponse)(nil),      // 16: bouncebot.SubmitSolutionResponse
-	(*MarkFinishedSolvingRequest)(nil),  // 17: bouncebot.MarkFinishedSolvingRequest
-	(*MarkFinishedSolvingResponse)(nil), // 18: bouncebot.MarkFinishedSolvingResponse
-	(*MarkReadyForNextRequest)(nil),     // 19: bouncebot.MarkReadyForNextRequest
-	(*MarkReadyForNextResponse)(nil),    // 20: bouncebot.MarkReadyForNextResponse
-	(*SolverResult)(nil),                // 21: bouncebot.SolverResult
-	(*UpdateRoomSettingsRequest)(nil),   // 22: bouncebot.UpdateRoomSettingsRequest
-	(*UpdateRoomSettingsResponse)(nil),  // 23: bouncebot.UpdateRoomSettingsResponse
-	(*BootPlayerRequest)(nil),           // 24: bouncebot.BootPlayerRequest
-	(*BootPlayerResponse)(nil),          // 25: bouncebot.BootPlayerResponse
-	(*LeaveRoomRequest)(nil),            // 26: bouncebot.LeaveRoomRequest
-	(*LeaveRoomResponse)(nil),           // 27: bouncebot.LeaveRoomResponse
-	(*DailyPuzzleInfo)(nil),             // 28: bouncebot.DailyPuzzleInfo
-	(*GetDailyChallengeRequest)(nil),    // 29: bouncebot.GetDailyChallengeRequest
-	(*GetDailyChallengeResponse)(nil),   // 30: bouncebot.GetDailyChallengeResponse
-	(*SubmitDailySolutionRequest)(nil),  // 31: bouncebot.SubmitDailySolutionRequest
-	(*SubmitDailySolutionResponse)(nil), // 32: bouncebot.SubmitDailySolutionResponse
-	(*GetServerInfoRequest)(nil),        // 33: bouncebot.GetServerInfoRequest
-	(*GetServerInfoResponse)(nil),       // 34: bouncebot.GetServerInfoResponse
-	(*timestamppb.Timestamp)(nil),       // 35: google.protobuf.Timestamp
+	(*Position)(nil),                         // 0: bouncebot.Position
+	(*Board)(nil),                            // 1: bouncebot.Board
+	(*BotPos)(nil),                           // 2: bouncebot.BotPos
+	(*Game)(nil),                             // 3: bouncebot.Game
+	(*Player)(nil),                           // 4: bouncebot.Player
+	(*PlayerSolution)(nil),                   // 5: bouncebot.PlayerSolution
+	(*PlayerScore)(nil),                      // 6: bouncebot.PlayerScore
+	(*RoomSettings)(nil),                     // 7: bouncebot.RoomSettings
+	(*Room)(nil),                             // 8: bouncebot.Room
+	(*CreateRoomRequest)(nil),                // 9: bouncebot.CreateRoomRequest
+	(*CreateRoomFromSharedBoardRequest)(nil), // 10: bouncebot.CreateRoomFromSharedBoardRequest
+	(*JoinRoomRequest)(nil),                  // 11: bouncebot.JoinRoomRequest
+	(*JoinRoomResponse)(nil),                 // 12: bouncebot.JoinRoomResponse
+	(*CreateRoomResponse)(nil),               // 13: bouncebot.CreateRoomResponse
+	(*GetRoomRequest)(nil),                   // 14: bouncebot.GetRoomRequest
+	(*StartGameRequest)(nil),                 // 15: bouncebot.StartGameRequest
+	(*SubmitSolutionRequest)(nil),            // 16: bouncebot.SubmitSolutionRequest
+	(*SubmitSolutionResponse)(nil),           // 17: bouncebot.SubmitSolutionResponse
+	(*MarkFinishedSolvingRequest)(nil),       // 18: bouncebot.MarkFinishedSolvingRequest
+	(*MarkFinishedSolvingResponse)(nil),      // 19: bouncebot.MarkFinishedSolvingResponse
+	(*MarkReadyForNextRequest)(nil),          // 20: bouncebot.MarkReadyForNextRequest
+	(*MarkReadyForNextResponse)(nil),         // 21: bouncebot.MarkReadyForNextResponse
+	(*SolverResult)(nil),                     // 22: bouncebot.SolverResult
+	(*UpdateRoomSettingsRequest)(nil),        // 23: bouncebot.UpdateRoomSettingsRequest
+	(*UpdateRoomSettingsResponse)(nil),       // 24: bouncebot.UpdateRoomSettingsResponse
+	(*BootPlayerRequest)(nil),                // 25: bouncebot.BootPlayerRequest
+	(*BootPlayerResponse)(nil),               // 26: bouncebot.BootPlayerResponse
+	(*LeaveRoomRequest)(nil),                 // 27: bouncebot.LeaveRoomRequest
+	(*LeaveRoomResponse)(nil),                // 28: bouncebot.LeaveRoomResponse
+	(*DailyPuzzleInfo)(nil),                  // 29: bouncebot.DailyPuzzleInfo
+	(*GetDailyChallengeRequest)(nil),         // 30: bouncebot.GetDailyChallengeRequest
+	(*GetDailyChallengeResponse)(nil),        // 31: bouncebot.GetDailyChallengeResponse
+	(*SubmitDailySolutionRequest)(nil),       // 32: bouncebot.SubmitDailySolutionRequest
+	(*SubmitDailySolutionResponse)(nil),      // 33: bouncebot.SubmitDailySolutionResponse
+	(*GetServerInfoRequest)(nil),             // 34: bouncebot.GetServerInfoRequest
+	(*GetServerInfoResponse)(nil),            // 35: bouncebot.GetServerInfoResponse
+	(*timestamppb.Timestamp)(nil),            // 36: google.protobuf.Timestamp
 }
 var file_bouncebot_proto_depIdxs = []int32{
 	0,  // 0: bouncebot.Board.v_walls:type_name -> bouncebot.Position
@@ -2249,16 +2311,16 @@ var file_bouncebot_proto_depIdxs = []int32{
 	1,  // 4: bouncebot.Game.board:type_name -> bouncebot.Board
 	2,  // 5: bouncebot.Game.bots:type_name -> bouncebot.BotPos
 	2,  // 6: bouncebot.Game.target:type_name -> bouncebot.BotPos
-	35, // 7: bouncebot.PlayerSolution.solved_at:type_name -> google.protobuf.Timestamp
+	36, // 7: bouncebot.PlayerSolution.solved_at:type_name -> google.protobuf.Timestamp
 	2,  // 8: bouncebot.PlayerSolution.moves:type_name -> bouncebot.BotPos
 	4,  // 9: bouncebot.Room.players:type_name -> bouncebot.Player
-	35, // 10: bouncebot.Room.created_at:type_name -> google.protobuf.Timestamp
+	36, // 10: bouncebot.Room.created_at:type_name -> google.protobuf.Timestamp
 	3,  // 11: bouncebot.Room.current_game:type_name -> bouncebot.Game
-	35, // 12: bouncebot.Room.game_started_at:type_name -> google.protobuf.Timestamp
+	36, // 12: bouncebot.Room.game_started_at:type_name -> google.protobuf.Timestamp
 	5,  // 13: bouncebot.Room.solutions:type_name -> bouncebot.PlayerSolution
 	6,  // 14: bouncebot.Room.scores:type_name -> bouncebot.PlayerScore
 	4,  // 15: bouncebot.Room.pending_players:type_name -> bouncebot.Player
-	21, // 16: bouncebot.Room.solver_results:type_name -> bouncebot.SolverResult
+	22, // 16: bouncebot.Room.solver_results:type_name -> bouncebot.SolverResult
 	7,  // 17: bouncebot.Room.settings:type_name -> bouncebot.RoomSettings
 	8,  // 18: bouncebot.JoinRoomResponse.room:type_name -> bouncebot.Room
 	8,  // 19: bouncebot.CreateRoomResponse.room:type_name -> bouncebot.Room
@@ -2267,36 +2329,38 @@ var file_bouncebot_proto_depIdxs = []int32{
 	2,  // 22: bouncebot.SolverResult.moves:type_name -> bouncebot.BotPos
 	7,  // 23: bouncebot.UpdateRoomSettingsRequest.settings:type_name -> bouncebot.RoomSettings
 	3,  // 24: bouncebot.DailyPuzzleInfo.game:type_name -> bouncebot.Game
-	28, // 25: bouncebot.GetDailyChallengeResponse.puzzles:type_name -> bouncebot.DailyPuzzleInfo
+	29, // 25: bouncebot.GetDailyChallengeResponse.puzzles:type_name -> bouncebot.DailyPuzzleInfo
 	2,  // 26: bouncebot.SubmitDailySolutionRequest.moves:type_name -> bouncebot.BotPos
 	9,  // 27: bouncebot.BounceBot.CreateRoom:input_type -> bouncebot.CreateRoomRequest
-	10, // 28: bouncebot.BounceBot.JoinRoom:input_type -> bouncebot.JoinRoomRequest
-	13, // 29: bouncebot.BounceBot.GetRoom:input_type -> bouncebot.GetRoomRequest
-	14, // 30: bouncebot.BounceBot.StartGame:input_type -> bouncebot.StartGameRequest
-	15, // 31: bouncebot.BounceBot.SubmitSolution:input_type -> bouncebot.SubmitSolutionRequest
-	17, // 32: bouncebot.BounceBot.MarkFinishedSolving:input_type -> bouncebot.MarkFinishedSolvingRequest
-	19, // 33: bouncebot.BounceBot.MarkReadyForNext:input_type -> bouncebot.MarkReadyForNextRequest
-	22, // 34: bouncebot.BounceBot.UpdateRoomSettings:input_type -> bouncebot.UpdateRoomSettingsRequest
-	24, // 35: bouncebot.BounceBot.BootPlayer:input_type -> bouncebot.BootPlayerRequest
-	26, // 36: bouncebot.BounceBot.LeaveRoom:input_type -> bouncebot.LeaveRoomRequest
-	29, // 37: bouncebot.BounceBot.GetDailyChallenge:input_type -> bouncebot.GetDailyChallengeRequest
-	31, // 38: bouncebot.BounceBot.SubmitDailySolution:input_type -> bouncebot.SubmitDailySolutionRequest
-	33, // 39: bouncebot.BounceBot.GetServerInfo:input_type -> bouncebot.GetServerInfoRequest
-	12, // 40: bouncebot.BounceBot.CreateRoom:output_type -> bouncebot.CreateRoomResponse
-	11, // 41: bouncebot.BounceBot.JoinRoom:output_type -> bouncebot.JoinRoomResponse
-	8,  // 42: bouncebot.BounceBot.GetRoom:output_type -> bouncebot.Room
-	8,  // 43: bouncebot.BounceBot.StartGame:output_type -> bouncebot.Room
-	16, // 44: bouncebot.BounceBot.SubmitSolution:output_type -> bouncebot.SubmitSolutionResponse
-	18, // 45: bouncebot.BounceBot.MarkFinishedSolving:output_type -> bouncebot.MarkFinishedSolvingResponse
-	20, // 46: bouncebot.BounceBot.MarkReadyForNext:output_type -> bouncebot.MarkReadyForNextResponse
-	23, // 47: bouncebot.BounceBot.UpdateRoomSettings:output_type -> bouncebot.UpdateRoomSettingsResponse
-	25, // 48: bouncebot.BounceBot.BootPlayer:output_type -> bouncebot.BootPlayerResponse
-	27, // 49: bouncebot.BounceBot.LeaveRoom:output_type -> bouncebot.LeaveRoomResponse
-	30, // 50: bouncebot.BounceBot.GetDailyChallenge:output_type -> bouncebot.GetDailyChallengeResponse
-	32, // 51: bouncebot.BounceBot.SubmitDailySolution:output_type -> bouncebot.SubmitDailySolutionResponse
-	34, // 52: bouncebot.BounceBot.GetServerInfo:output_type -> bouncebot.GetServerInfoResponse
-	40, // [40:53] is the sub-list for method output_type
-	27, // [27:40] is the sub-list for method input_type
+	11, // 28: bouncebot.BounceBot.JoinRoom:input_type -> bouncebot.JoinRoomRequest
+	14, // 29: bouncebot.BounceBot.GetRoom:input_type -> bouncebot.GetRoomRequest
+	15, // 30: bouncebot.BounceBot.StartGame:input_type -> bouncebot.StartGameRequest
+	16, // 31: bouncebot.BounceBot.SubmitSolution:input_type -> bouncebot.SubmitSolutionRequest
+	18, // 32: bouncebot.BounceBot.MarkFinishedSolving:input_type -> bouncebot.MarkFinishedSolvingRequest
+	20, // 33: bouncebot.BounceBot.MarkReadyForNext:input_type -> bouncebot.MarkReadyForNextRequest
+	23, // 34: bouncebot.BounceBot.UpdateRoomSettings:input_type -> bouncebot.UpdateRoomSettingsRequest
+	25, // 35: bouncebot.BounceBot.BootPlayer:input_type -> bouncebot.BootPlayerRequest
+	27, // 36: bouncebot.BounceBot.LeaveRoom:input_type -> bouncebot.LeaveRoomRequest
+	10, // 37: bouncebot.BounceBot.CreateRoomFromSharedBoard:input_type -> bouncebot.CreateRoomFromSharedBoardRequest
+	30, // 38: bouncebot.BounceBot.GetDailyChallenge:input_type -> bouncebot.GetDailyChallengeRequest
+	32, // 39: bouncebot.BounceBot.SubmitDailySolution:input_type -> bouncebot.SubmitDailySolutionRequest
+	34, // 40: bouncebot.BounceBot.GetServerInfo:input_type -> bouncebot.GetServerInfoRequest
+	13, // 41: bouncebot.BounceBot.CreateRoom:output_type -> bouncebot.CreateRoomResponse
+	12, // 42: bouncebot.BounceBot.JoinRoom:output_type -> bouncebot.JoinRoomResponse
+	8,  // 43: bouncebot.BounceBot.GetRoom:output_type -> bouncebot.Room
+	8,  // 44: bouncebot.BounceBot.StartGame:output_type -> bouncebot.Room
+	17, // 45: bouncebot.BounceBot.SubmitSolution:output_type -> bouncebot.SubmitSolutionResponse
+	19, // 46: bouncebot.BounceBot.MarkFinishedSolving:output_type -> bouncebot.MarkFinishedSolvingResponse
+	21, // 47: bouncebot.BounceBot.MarkReadyForNext:output_type -> bouncebot.MarkReadyForNextResponse
+	24, // 48: bouncebot.BounceBot.UpdateRoomSettings:output_type -> bouncebot.UpdateRoomSettingsResponse
+	26, // 49: bouncebot.BounceBot.BootPlayer:output_type -> bouncebot.BootPlayerResponse
+	28, // 50: bouncebot.BounceBot.LeaveRoom:output_type -> bouncebot.LeaveRoomResponse
+	13, // 51: bouncebot.BounceBot.CreateRoomFromSharedBoard:output_type -> bouncebot.CreateRoomResponse
+	31, // 52: bouncebot.BounceBot.GetDailyChallenge:output_type -> bouncebot.GetDailyChallengeResponse
+	33, // 53: bouncebot.BounceBot.SubmitDailySolution:output_type -> bouncebot.SubmitDailySolutionResponse
+	35, // 54: bouncebot.BounceBot.GetServerInfo:output_type -> bouncebot.GetServerInfoResponse
+	41, // [41:55] is the sub-list for method output_type
+	27, // [27:41] is the sub-list for method input_type
 	27, // [27:27] is the sub-list for extension type_name
 	27, // [27:27] is the sub-list for extension extendee
 	0,  // [0:27] is the sub-list for field type_name
@@ -2313,7 +2377,7 @@ func file_bouncebot_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bouncebot_proto_rawDesc), len(file_bouncebot_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   35,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/bouncebot.proto
+++ b/proto/bouncebot.proto
@@ -19,6 +19,7 @@ service BounceBot {
   rpc UpdateRoomSettings (UpdateRoomSettingsRequest) returns (UpdateRoomSettingsResponse) {}
   rpc BootPlayer (BootPlayerRequest) returns (BootPlayerResponse) {}
   rpc LeaveRoom (LeaveRoomRequest) returns (LeaveRoomResponse) {}
+  rpc CreateRoomFromSharedBoard (CreateRoomFromSharedBoardRequest) returns (CreateRoomResponse) {}
 
   // Daily challenge
   rpc GetDailyChallenge (GetDailyChallengeRequest) returns (GetDailyChallengeResponse) {}
@@ -117,6 +118,14 @@ message Room {
 message CreateRoomRequest {
   string player_name = 1;
   bool is_single_player = 2;  // If true, only the creator can be in this room
+}
+
+// Creates a new single-player room seeded with a specific board, decoded
+// from a share code (see planning/BOARD_SHARING_DESIGN.md). Returns the same
+// shape as CreateRoomResponse.
+message CreateRoomFromSharedBoardRequest {
+  string player_name = 1;
+  string share_code = 2;
 }
 
 message JoinRoomRequest {

--- a/proto/bouncebot_grpc.pb.go
+++ b/proto/bouncebot_grpc.pb.go
@@ -19,19 +19,20 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	BounceBot_CreateRoom_FullMethodName          = "/bouncebot.BounceBot/CreateRoom"
-	BounceBot_JoinRoom_FullMethodName            = "/bouncebot.BounceBot/JoinRoom"
-	BounceBot_GetRoom_FullMethodName             = "/bouncebot.BounceBot/GetRoom"
-	BounceBot_StartGame_FullMethodName           = "/bouncebot.BounceBot/StartGame"
-	BounceBot_SubmitSolution_FullMethodName      = "/bouncebot.BounceBot/SubmitSolution"
-	BounceBot_MarkFinishedSolving_FullMethodName = "/bouncebot.BounceBot/MarkFinishedSolving"
-	BounceBot_MarkReadyForNext_FullMethodName    = "/bouncebot.BounceBot/MarkReadyForNext"
-	BounceBot_UpdateRoomSettings_FullMethodName  = "/bouncebot.BounceBot/UpdateRoomSettings"
-	BounceBot_BootPlayer_FullMethodName          = "/bouncebot.BounceBot/BootPlayer"
-	BounceBot_LeaveRoom_FullMethodName           = "/bouncebot.BounceBot/LeaveRoom"
-	BounceBot_GetDailyChallenge_FullMethodName   = "/bouncebot.BounceBot/GetDailyChallenge"
-	BounceBot_SubmitDailySolution_FullMethodName = "/bouncebot.BounceBot/SubmitDailySolution"
-	BounceBot_GetServerInfo_FullMethodName       = "/bouncebot.BounceBot/GetServerInfo"
+	BounceBot_CreateRoom_FullMethodName                = "/bouncebot.BounceBot/CreateRoom"
+	BounceBot_JoinRoom_FullMethodName                  = "/bouncebot.BounceBot/JoinRoom"
+	BounceBot_GetRoom_FullMethodName                   = "/bouncebot.BounceBot/GetRoom"
+	BounceBot_StartGame_FullMethodName                 = "/bouncebot.BounceBot/StartGame"
+	BounceBot_SubmitSolution_FullMethodName            = "/bouncebot.BounceBot/SubmitSolution"
+	BounceBot_MarkFinishedSolving_FullMethodName       = "/bouncebot.BounceBot/MarkFinishedSolving"
+	BounceBot_MarkReadyForNext_FullMethodName          = "/bouncebot.BounceBot/MarkReadyForNext"
+	BounceBot_UpdateRoomSettings_FullMethodName        = "/bouncebot.BounceBot/UpdateRoomSettings"
+	BounceBot_BootPlayer_FullMethodName                = "/bouncebot.BounceBot/BootPlayer"
+	BounceBot_LeaveRoom_FullMethodName                 = "/bouncebot.BounceBot/LeaveRoom"
+	BounceBot_CreateRoomFromSharedBoard_FullMethodName = "/bouncebot.BounceBot/CreateRoomFromSharedBoard"
+	BounceBot_GetDailyChallenge_FullMethodName         = "/bouncebot.BounceBot/GetDailyChallenge"
+	BounceBot_SubmitDailySolution_FullMethodName       = "/bouncebot.BounceBot/SubmitDailySolution"
+	BounceBot_GetServerInfo_FullMethodName             = "/bouncebot.BounceBot/GetServerInfo"
 )
 
 // BounceBotClient is the client API for BounceBot service.
@@ -51,6 +52,7 @@ type BounceBotClient interface {
 	UpdateRoomSettings(ctx context.Context, in *UpdateRoomSettingsRequest, opts ...grpc.CallOption) (*UpdateRoomSettingsResponse, error)
 	BootPlayer(ctx context.Context, in *BootPlayerRequest, opts ...grpc.CallOption) (*BootPlayerResponse, error)
 	LeaveRoom(ctx context.Context, in *LeaveRoomRequest, opts ...grpc.CallOption) (*LeaveRoomResponse, error)
+	CreateRoomFromSharedBoard(ctx context.Context, in *CreateRoomFromSharedBoardRequest, opts ...grpc.CallOption) (*CreateRoomResponse, error)
 	// Daily challenge
 	GetDailyChallenge(ctx context.Context, in *GetDailyChallengeRequest, opts ...grpc.CallOption) (*GetDailyChallengeResponse, error)
 	SubmitDailySolution(ctx context.Context, in *SubmitDailySolutionRequest, opts ...grpc.CallOption) (*SubmitDailySolutionResponse, error)
@@ -166,6 +168,16 @@ func (c *bounceBotClient) LeaveRoom(ctx context.Context, in *LeaveRoomRequest, o
 	return out, nil
 }
 
+func (c *bounceBotClient) CreateRoomFromSharedBoard(ctx context.Context, in *CreateRoomFromSharedBoardRequest, opts ...grpc.CallOption) (*CreateRoomResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateRoomResponse)
+	err := c.cc.Invoke(ctx, BounceBot_CreateRoomFromSharedBoard_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *bounceBotClient) GetDailyChallenge(ctx context.Context, in *GetDailyChallengeRequest, opts ...grpc.CallOption) (*GetDailyChallengeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetDailyChallengeResponse)
@@ -213,6 +225,7 @@ type BounceBotServer interface {
 	UpdateRoomSettings(context.Context, *UpdateRoomSettingsRequest) (*UpdateRoomSettingsResponse, error)
 	BootPlayer(context.Context, *BootPlayerRequest) (*BootPlayerResponse, error)
 	LeaveRoom(context.Context, *LeaveRoomRequest) (*LeaveRoomResponse, error)
+	CreateRoomFromSharedBoard(context.Context, *CreateRoomFromSharedBoardRequest) (*CreateRoomResponse, error)
 	// Daily challenge
 	GetDailyChallenge(context.Context, *GetDailyChallengeRequest) (*GetDailyChallengeResponse, error)
 	SubmitDailySolution(context.Context, *SubmitDailySolutionRequest) (*SubmitDailySolutionResponse, error)
@@ -257,6 +270,9 @@ func (UnimplementedBounceBotServer) BootPlayer(context.Context, *BootPlayerReque
 }
 func (UnimplementedBounceBotServer) LeaveRoom(context.Context, *LeaveRoomRequest) (*LeaveRoomResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method LeaveRoom not implemented")
+}
+func (UnimplementedBounceBotServer) CreateRoomFromSharedBoard(context.Context, *CreateRoomFromSharedBoardRequest) (*CreateRoomResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateRoomFromSharedBoard not implemented")
 }
 func (UnimplementedBounceBotServer) GetDailyChallenge(context.Context, *GetDailyChallengeRequest) (*GetDailyChallengeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetDailyChallenge not implemented")
@@ -468,6 +484,24 @@ func _BounceBot_LeaveRoom_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BounceBot_CreateRoomFromSharedBoard_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateRoomFromSharedBoardRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BounceBotServer).CreateRoomFromSharedBoard(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BounceBot_CreateRoomFromSharedBoard_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BounceBotServer).CreateRoomFromSharedBoard(ctx, req.(*CreateRoomFromSharedBoardRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _BounceBot_GetDailyChallenge_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetDailyChallengeRequest)
 	if err := dec(in); err != nil {
@@ -568,6 +602,10 @@ var BounceBot_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "LeaveRoom",
 			Handler:    _BounceBot_LeaveRoom_Handler,
+		},
+		{
+			MethodName: "CreateRoomFromSharedBoard",
+			Handler:    _BounceBot_CreateRoomFromSharedBoard_Handler,
 		},
 		{
 			MethodName: "GetDailyChallenge",

--- a/proto/protoconnect/bouncebot.connect.go
+++ b/proto/protoconnect/bouncebot.connect.go
@@ -57,6 +57,9 @@ const (
 	BounceBotBootPlayerProcedure = "/bouncebot.BounceBot/BootPlayer"
 	// BounceBotLeaveRoomProcedure is the fully-qualified name of the BounceBot's LeaveRoom RPC.
 	BounceBotLeaveRoomProcedure = "/bouncebot.BounceBot/LeaveRoom"
+	// BounceBotCreateRoomFromSharedBoardProcedure is the fully-qualified name of the BounceBot's
+	// CreateRoomFromSharedBoard RPC.
+	BounceBotCreateRoomFromSharedBoardProcedure = "/bouncebot.BounceBot/CreateRoomFromSharedBoard"
 	// BounceBotGetDailyChallengeProcedure is the fully-qualified name of the BounceBot's
 	// GetDailyChallenge RPC.
 	BounceBotGetDailyChallengeProcedure = "/bouncebot.BounceBot/GetDailyChallenge"
@@ -80,6 +83,7 @@ type BounceBotClient interface {
 	UpdateRoomSettings(context.Context, *connect.Request[proto.UpdateRoomSettingsRequest]) (*connect.Response[proto.UpdateRoomSettingsResponse], error)
 	BootPlayer(context.Context, *connect.Request[proto.BootPlayerRequest]) (*connect.Response[proto.BootPlayerResponse], error)
 	LeaveRoom(context.Context, *connect.Request[proto.LeaveRoomRequest]) (*connect.Response[proto.LeaveRoomResponse], error)
+	CreateRoomFromSharedBoard(context.Context, *connect.Request[proto.CreateRoomFromSharedBoardRequest]) (*connect.Response[proto.CreateRoomResponse], error)
 	// Daily challenge
 	GetDailyChallenge(context.Context, *connect.Request[proto.GetDailyChallengeRequest]) (*connect.Response[proto.GetDailyChallengeResponse], error)
 	SubmitDailySolution(context.Context, *connect.Request[proto.SubmitDailySolutionRequest]) (*connect.Response[proto.SubmitDailySolutionResponse], error)
@@ -158,6 +162,12 @@ func NewBounceBotClient(httpClient connect.HTTPClient, baseURL string, opts ...c
 			connect.WithSchema(bounceBotMethods.ByName("LeaveRoom")),
 			connect.WithClientOptions(opts...),
 		),
+		createRoomFromSharedBoard: connect.NewClient[proto.CreateRoomFromSharedBoardRequest, proto.CreateRoomResponse](
+			httpClient,
+			baseURL+BounceBotCreateRoomFromSharedBoardProcedure,
+			connect.WithSchema(bounceBotMethods.ByName("CreateRoomFromSharedBoard")),
+			connect.WithClientOptions(opts...),
+		),
 		getDailyChallenge: connect.NewClient[proto.GetDailyChallengeRequest, proto.GetDailyChallengeResponse](
 			httpClient,
 			baseURL+BounceBotGetDailyChallengeProcedure,
@@ -181,19 +191,20 @@ func NewBounceBotClient(httpClient connect.HTTPClient, baseURL string, opts ...c
 
 // bounceBotClient implements BounceBotClient.
 type bounceBotClient struct {
-	createRoom          *connect.Client[proto.CreateRoomRequest, proto.CreateRoomResponse]
-	joinRoom            *connect.Client[proto.JoinRoomRequest, proto.JoinRoomResponse]
-	getRoom             *connect.Client[proto.GetRoomRequest, proto.Room]
-	startGame           *connect.Client[proto.StartGameRequest, proto.Room]
-	submitSolution      *connect.Client[proto.SubmitSolutionRequest, proto.SubmitSolutionResponse]
-	markFinishedSolving *connect.Client[proto.MarkFinishedSolvingRequest, proto.MarkFinishedSolvingResponse]
-	markReadyForNext    *connect.Client[proto.MarkReadyForNextRequest, proto.MarkReadyForNextResponse]
-	updateRoomSettings  *connect.Client[proto.UpdateRoomSettingsRequest, proto.UpdateRoomSettingsResponse]
-	bootPlayer          *connect.Client[proto.BootPlayerRequest, proto.BootPlayerResponse]
-	leaveRoom           *connect.Client[proto.LeaveRoomRequest, proto.LeaveRoomResponse]
-	getDailyChallenge   *connect.Client[proto.GetDailyChallengeRequest, proto.GetDailyChallengeResponse]
-	submitDailySolution *connect.Client[proto.SubmitDailySolutionRequest, proto.SubmitDailySolutionResponse]
-	getServerInfo       *connect.Client[proto.GetServerInfoRequest, proto.GetServerInfoResponse]
+	createRoom                *connect.Client[proto.CreateRoomRequest, proto.CreateRoomResponse]
+	joinRoom                  *connect.Client[proto.JoinRoomRequest, proto.JoinRoomResponse]
+	getRoom                   *connect.Client[proto.GetRoomRequest, proto.Room]
+	startGame                 *connect.Client[proto.StartGameRequest, proto.Room]
+	submitSolution            *connect.Client[proto.SubmitSolutionRequest, proto.SubmitSolutionResponse]
+	markFinishedSolving       *connect.Client[proto.MarkFinishedSolvingRequest, proto.MarkFinishedSolvingResponse]
+	markReadyForNext          *connect.Client[proto.MarkReadyForNextRequest, proto.MarkReadyForNextResponse]
+	updateRoomSettings        *connect.Client[proto.UpdateRoomSettingsRequest, proto.UpdateRoomSettingsResponse]
+	bootPlayer                *connect.Client[proto.BootPlayerRequest, proto.BootPlayerResponse]
+	leaveRoom                 *connect.Client[proto.LeaveRoomRequest, proto.LeaveRoomResponse]
+	createRoomFromSharedBoard *connect.Client[proto.CreateRoomFromSharedBoardRequest, proto.CreateRoomResponse]
+	getDailyChallenge         *connect.Client[proto.GetDailyChallengeRequest, proto.GetDailyChallengeResponse]
+	submitDailySolution       *connect.Client[proto.SubmitDailySolutionRequest, proto.SubmitDailySolutionResponse]
+	getServerInfo             *connect.Client[proto.GetServerInfoRequest, proto.GetServerInfoResponse]
 }
 
 // CreateRoom calls bouncebot.BounceBot.CreateRoom.
@@ -246,6 +257,11 @@ func (c *bounceBotClient) LeaveRoom(ctx context.Context, req *connect.Request[pr
 	return c.leaveRoom.CallUnary(ctx, req)
 }
 
+// CreateRoomFromSharedBoard calls bouncebot.BounceBot.CreateRoomFromSharedBoard.
+func (c *bounceBotClient) CreateRoomFromSharedBoard(ctx context.Context, req *connect.Request[proto.CreateRoomFromSharedBoardRequest]) (*connect.Response[proto.CreateRoomResponse], error) {
+	return c.createRoomFromSharedBoard.CallUnary(ctx, req)
+}
+
 // GetDailyChallenge calls bouncebot.BounceBot.GetDailyChallenge.
 func (c *bounceBotClient) GetDailyChallenge(ctx context.Context, req *connect.Request[proto.GetDailyChallengeRequest]) (*connect.Response[proto.GetDailyChallengeResponse], error) {
 	return c.getDailyChallenge.CallUnary(ctx, req)
@@ -274,6 +290,7 @@ type BounceBotHandler interface {
 	UpdateRoomSettings(context.Context, *connect.Request[proto.UpdateRoomSettingsRequest]) (*connect.Response[proto.UpdateRoomSettingsResponse], error)
 	BootPlayer(context.Context, *connect.Request[proto.BootPlayerRequest]) (*connect.Response[proto.BootPlayerResponse], error)
 	LeaveRoom(context.Context, *connect.Request[proto.LeaveRoomRequest]) (*connect.Response[proto.LeaveRoomResponse], error)
+	CreateRoomFromSharedBoard(context.Context, *connect.Request[proto.CreateRoomFromSharedBoardRequest]) (*connect.Response[proto.CreateRoomResponse], error)
 	// Daily challenge
 	GetDailyChallenge(context.Context, *connect.Request[proto.GetDailyChallengeRequest]) (*connect.Response[proto.GetDailyChallengeResponse], error)
 	SubmitDailySolution(context.Context, *connect.Request[proto.SubmitDailySolutionRequest]) (*connect.Response[proto.SubmitDailySolutionResponse], error)
@@ -348,6 +365,12 @@ func NewBounceBotHandler(svc BounceBotHandler, opts ...connect.HandlerOption) (s
 		connect.WithSchema(bounceBotMethods.ByName("LeaveRoom")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bounceBotCreateRoomFromSharedBoardHandler := connect.NewUnaryHandler(
+		BounceBotCreateRoomFromSharedBoardProcedure,
+		svc.CreateRoomFromSharedBoard,
+		connect.WithSchema(bounceBotMethods.ByName("CreateRoomFromSharedBoard")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bounceBotGetDailyChallengeHandler := connect.NewUnaryHandler(
 		BounceBotGetDailyChallengeProcedure,
 		svc.GetDailyChallenge,
@@ -388,6 +411,8 @@ func NewBounceBotHandler(svc BounceBotHandler, opts ...connect.HandlerOption) (s
 			bounceBotBootPlayerHandler.ServeHTTP(w, r)
 		case BounceBotLeaveRoomProcedure:
 			bounceBotLeaveRoomHandler.ServeHTTP(w, r)
+		case BounceBotCreateRoomFromSharedBoardProcedure:
+			bounceBotCreateRoomFromSharedBoardHandler.ServeHTTP(w, r)
 		case BounceBotGetDailyChallengeProcedure:
 			bounceBotGetDailyChallengeHandler.ServeHTTP(w, r)
 		case BounceBotSubmitDailySolutionProcedure:
@@ -441,6 +466,10 @@ func (UnimplementedBounceBotHandler) BootPlayer(context.Context, *connect.Reques
 
 func (UnimplementedBounceBotHandler) LeaveRoom(context.Context, *connect.Request[proto.LeaveRoomRequest]) (*connect.Response[proto.LeaveRoomResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bouncebot.BounceBot.LeaveRoom is not implemented"))
+}
+
+func (UnimplementedBounceBotHandler) CreateRoomFromSharedBoard(context.Context, *connect.Request[proto.CreateRoomFromSharedBoardRequest]) (*connect.Response[proto.CreateRoomResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bouncebot.BounceBot.CreateRoomFromSharedBoard is not implemented"))
 }
 
 func (UnimplementedBounceBotHandler) GetDailyChallenge(context.Context, *connect.Request[proto.GetDailyChallengeRequest]) (*connect.Response[proto.GetDailyChallengeResponse], error) {

--- a/server/bouncebotserver.go
+++ b/server/bouncebotserver.go
@@ -89,6 +89,34 @@ func (s *bounceBotServer) CreateRoom(ctx context.Context, req *connect.Request[p
 	}), nil
 }
 
+func (s *bounceBotServer) CreateRoomFromSharedBoard(ctx context.Context, req *connect.Request[pb.CreateRoomFromSharedBoardRequest]) (*connect.Response[pb.CreateRoomResponse], error) {
+	clientIP := ratelimit.ClientIPFromContext(ctx)
+	if clientIP != "" && s.createRoomLimiter != nil && !s.createRoomLimiter.Allow(clientIP) {
+		return nil, connect.NewError(connect.CodeResourceExhausted, nil)
+	}
+
+	playerName, err := validatePlayerName(req.Msg.PlayerName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	game, err := model.DecodeShareCode(req.Msg.ShareCode)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	roomProto, playerID, sessionToken, err := s.rooms.CreateRoomFromBoard(playerName, game)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	return connect.NewResponse(&pb.CreateRoomResponse{
+		Room:         roomProto,
+		PlayerId:     playerID,
+		SessionToken: sessionToken,
+	}), nil
+}
+
 func (s *bounceBotServer) JoinRoom(_ context.Context, req *connect.Request[pb.JoinRoomRequest]) (*connect.Response[pb.JoinRoomResponse], error) {
 	playerName, err := validatePlayerName(req.Msg.PlayerName)
 	if err != nil {

--- a/server/room/service.go
+++ b/server/room/service.go
@@ -85,6 +85,35 @@ func (s *RoomService) Create(playerName string, isSinglePlayer bool) (*Room, str
 	return s.repo.Create(playerName, isSinglePlayer)
 }
 
+// CreateRoomFromBoard creates a new single-player room and immediately
+// commits the given game as its current game, bypassing normal board
+// selection entirely - the board is already fully specified (e.g. decoded
+// from a share code), so there's nothing to generate or filter by minimum
+// solution length. Returns the room proto, player ID, and session token.
+func (s *RoomService) CreateRoomFromBoard(playerName string, game *model.Game) (*pb.Room, string, string, error) {
+	room, playerID, sessionToken := s.repo.Create(playerName, true)
+
+	roomLocked, unlock := s.repo.GetWithLock(room.ID)
+	if roomLocked == nil {
+		unlock()
+		return nil, "", "", fmt.Errorf("room not found: %s", room.ID)
+	}
+	signals := s.gameMgr.CommitNewGame(roomLocked, game)
+	proto := roomLocked.ToProto()
+	// Make a copy for callback (room might be modified after unlock)
+	roomCopy := *roomLocked
+	unlock()
+
+	s.processSignals(signals)
+
+	// Notify about game start (for solver etc)
+	if s.onGameStart != nil && roomCopy.CurrentGame != nil {
+		s.onGameStart(&roomCopy)
+	}
+
+	return proto, playerID, sessionToken, nil
+}
+
 // Join adds a player to an existing room.
 // Returns the room proto, the new player's ID, session token, and any error.
 func (s *RoomService) Join(roomID, playerName string) (*pb.Room, string, string, error) {

--- a/server/room/service_test.go
+++ b/server/room/service_test.go
@@ -161,6 +161,59 @@ func TestService_StartGame_DoesNotHoldLockDuringSearch(t *testing.T) {
 	<-done
 }
 
+func TestService_CreateRoomFromBoard(t *testing.T) {
+	svc := NewRoomService()
+	game := model.Game1()
+
+	proto, playerID, sessionToken, err := svc.CreateRoomFromBoard("Alice", game)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if playerID == "" || sessionToken == "" {
+		t.Error("expected a non-empty player ID and session token")
+	}
+	if !proto.IsSinglePlayer {
+		t.Error("expected the room to be single-player")
+	}
+	if proto.CurrentGame == nil {
+		t.Fatal("expected game to be set")
+	}
+	if proto.GameStartedAt == nil {
+		t.Error("expected GameStartedAt to be set")
+	}
+	if proto.CurrentGame.Target.Pos.X != int32(game.Target.Pos.X) || proto.CurrentGame.Target.Pos.Y != int32(game.Target.Pos.Y) {
+		t.Errorf("expected the room's game to match the given board's target, got %v want %v", proto.CurrentGame.Target.Pos, game.Target.Pos)
+	}
+
+	// The session token should actually work for subsequent calls.
+	if _, err := svc.ValidateSessionToken(proto.Id, sessionToken); err != nil {
+		t.Errorf("expected session token to validate, got error: %v", err)
+	}
+}
+
+func TestService_CreateRoomFromBoard_FiresOnGameStart(t *testing.T) {
+	svc := NewRoomService()
+
+	var gotGame *model.Game
+	svc.SetOnGameStart(func(r *Room) {
+		gotGame = r.CurrentGame
+	})
+
+	game := model.Game1()
+	_, _, _, err := svc.CreateRoomFromBoard("Alice", game)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotGame == nil {
+		t.Fatal("expected onGameStart to fire with the created room's game")
+	}
+	if !gotGame.Equals(game) {
+		t.Errorf("onGameStart's game did not match the given board:\ngot:\n%s\nwant:\n%s", gotGame.String(), game.String())
+	}
+}
+
 func TestService_SubmitSolution_ValidSolution(t *testing.T) {
 	svc := NewRoomService()
 	mock := &mockBroadcaster{}


### PR DESCRIPTION
## Summary
- New "Share Board" feature: a blue share button next to the game title opens a modal with a QR code and copyable link for the current board.
- The link/QR encodes the full board (walls, target, bot positions) directly, so it's self-contained and works without server-side board storage — opening it drops the recipient into a solo room seeded with that exact board.
- Encoding format and design rationale are in `planning/BOARD_SHARING_DESIGN.md`.
- Cross-language parity between the Go encoder/decoder and the TS encoder is verified with a shared fixed test vector.
- Also fixes: share button was misaligned (screen edge instead of board edge) on narrow/vertical layouts, and the Share Board modal now closes on Escape.

## Test plan
- [x] `go test ./model/... ./server/...` — all pass
- [x] `vue-tsc --noEmit` — clean
- [x] `vitest run` — 92 tests pass, including Go/TS share-code cross-parity fixed vector
- [x] Manual: created a solo board, shared it via link in a new tab, confirmed the resulting room's walls/target/bots are byte-identical to the source (verified via direct RPC diff, not just visually)
- [x] Manual: played a move in the shared-board room to confirm it's fully playable
- [x] Manual: verified share button alignment and Escape-to-close in both desktop and narrow/vertical layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)