### PR TITLE
Fix players getting booted from rooms via stale WebSocket connections

### DIFF
--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -100,7 +100,7 @@ type Client struct {
 type Hub struct {
 	mu            sync.RWMutex
 	rooms         map[string]map[*Client]bool // roomID -> clients
-	activeClients map[string]*Client          // "roomID:playerID" -> current client
+	activeClients map[string]int              // "roomID:playerID" -> number of open connections
 	store         *room.RoomService
 	config        *config.Config
 	upgrader      websocket.Upgrader
@@ -110,7 +110,7 @@ type Hub struct {
 func NewHub(store *room.RoomService, cfg *config.Config) *Hub {
 	h := &Hub{
 		rooms:         make(map[string]map[*Client]bool),
-		activeClients: make(map[string]*Client),
+		activeClients: make(map[string]int),
 		store:         store,
 		config:        cfg,
 	}
@@ -135,29 +135,42 @@ func (h *Hub) register(client *Client) {
 
 	if client.playerID != "" {
 		key := fmt.Sprintf("%s:%s", client.roomID, client.playerID)
-		h.activeClients[key] = client
+		h.activeClients[key]++
 	}
 
 	log.Printf("WebSocket: client connected to room %s (total: %d)", client.roomID, len(h.rooms[client.roomID]))
 }
 
-// unregister removes a client from a room.
+// unregister removes a client from a room. A player is only marked
+// disconnected once their last open connection closes - a player can briefly
+// hold more than one connection (e.g. a duplicate tab, or an old connection
+// that hasn't noticed a reconnect yet), and closing one of those must not
+// mark a player disconnected while another of their connections is still
+// live.
 func (h *Hub) unregister(client *Client) {
 	shouldDisconnect := false
 
 	h.mu.Lock()
+	removed := false
 	if clients, ok := h.rooms[client.roomID]; ok {
 		if _, ok := clients[client]; ok {
 			delete(clients, client)
+			removed = true
 			log.Printf("WebSocket: client disconnected from room %s (remaining: %d)", client.roomID, len(clients))
 			if len(clients) == 0 {
 				delete(h.rooms, client.roomID)
 			}
 		}
 	}
-	if client.playerID != "" {
+	// Gate on removed so a client that's unregistered more than once (e.g.
+	// once from Broadcast's failed-send path, again from its own readPump
+	// exiting) only decrements the count the first time.
+	if removed && client.playerID != "" {
 		key := fmt.Sprintf("%s:%s", client.roomID, client.playerID)
-		if h.activeClients[key] == client {
+		if h.activeClients[key] > 0 {
+			h.activeClients[key]--
+		}
+		if h.activeClients[key] <= 0 {
 			delete(h.activeClients, key)
 			shouldDisconnect = true
 		}

--- a/server/ws/hub_test.go
+++ b/server/ws/hub_test.go
@@ -304,55 +304,6 @@ func TestMultipleClientsInRoom(t *testing.T) {
 	hub.unregister(client3)
 }
 
-func TestStaleClientUnregisterSkipsDisconnect(t *testing.T) {
-	store := room.NewRoomService()
-	cfg := &config.Config{}
-	hub := NewHub(store, cfg)
-
-	oldClient := mockClient(hub, "ROOM1", "player1")
-	newClient := mockClient(hub, "ROOM1", "player1")
-
-	// Register old client, then new client (simulates reconnection)
-	hub.register(oldClient)
-	hub.register(newClient)
-
-	// Verify new client is the active one
-	hub.mu.RLock()
-	activeKey := "ROOM1:player1"
-	if hub.activeClients[activeKey] != newClient {
-		t.Error("expected newClient to be the active client after re-register")
-	}
-	hub.mu.RUnlock()
-
-	// Unregister the OLD (stale) client
-	hub.unregister(oldClient)
-
-	// New client should still be active
-	hub.mu.RLock()
-	if hub.activeClients[activeKey] != newClient {
-		t.Error("expected newClient to remain active after stale unregister")
-	}
-	hub.mu.RUnlock()
-
-	// New client's done channel should still be open
-	select {
-	case <-newClient.done:
-		t.Error("newClient's done channel should not be closed")
-	default:
-		// Expected: channel is still open
-	}
-
-	// Old client's done channel should be closed
-	select {
-	case <-oldClient.done:
-		// Expected: channel is closed
-	default:
-		t.Error("oldClient's done channel should be closed")
-	}
-
-	hub.unregister(newClient)
-}
-
 func TestActiveClientUnregisterCleansUp(t *testing.T) {
 	store := room.NewRoomService()
 	cfg := &config.Config{}
@@ -363,8 +314,8 @@ func TestActiveClientUnregisterCleansUp(t *testing.T) {
 
 	activeKey := "ROOM1:player1"
 	hub.mu.RLock()
-	if hub.activeClients[activeKey] != client {
-		t.Error("expected client in activeClients after register")
+	if hub.activeClients[activeKey] != 1 {
+		t.Errorf("expected 1 active connection after register, got %d", hub.activeClients[activeKey])
 	}
 	hub.mu.RUnlock()
 
@@ -382,6 +333,59 @@ func TestActiveClientUnregisterCleansUp(t *testing.T) {
 		// Expected
 	default:
 		t.Error("client's done channel should be closed after unregister")
+	}
+}
+
+// TestDuplicateConnectionUnregisterKeepsPlayerConnected covers the scenario
+// that used to boot players out of rooms mid-game: a player briefly holds two
+// open connections for the same room (e.g. a duplicate tab, or a flaky
+// reconnect), and one of them closes while the other is still live. Closing
+// EITHER connection - not just the one registered last - must not mark the
+// player disconnected while the other stays open, since the surviving
+// connection is what the player is actually still using.
+func TestDuplicateConnectionUnregisterKeepsPlayerConnected(t *testing.T) {
+	for _, closeFirst := range []string{"first-registered", "last-registered"} {
+		t.Run(closeFirst, func(t *testing.T) {
+			store := room.NewRoomService()
+			cfg := &config.Config{}
+			hub := NewHub(store, cfg)
+
+			createdRoom, playerID, _ := store.Create("Mike", false)
+			roomID := createdRoom.ID
+
+			clientA := mockClient(hub, roomID, playerID)
+			clientB := mockClient(hub, roomID, playerID)
+
+			hub.register(clientA)
+			hub.register(clientB)
+
+			activeKey := roomID + ":" + playerID
+			hub.mu.RLock()
+			if hub.activeClients[activeKey] != 2 {
+				t.Fatalf("expected 2 active connections after both register, got %d", hub.activeClients[activeKey])
+			}
+			hub.mu.RUnlock()
+
+			if closeFirst == "first-registered" {
+				hub.unregister(clientA)
+			} else {
+				hub.unregister(clientB)
+			}
+
+			hub.mu.RLock()
+			if hub.activeClients[activeKey] != 1 {
+				t.Errorf("expected 1 remaining active connection, got %d", hub.activeClients[activeKey])
+			}
+			hub.mu.RUnlock()
+
+			rm, err := store.Get(roomID)
+			if err != nil {
+				t.Fatalf("room disappeared: %v", err)
+			}
+			if rm.Players[0].Status != room.PlayerStatusConnected {
+				t.Errorf("expected player to remain connected while one connection is still open, got status %q", rm.Players[0].Status)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Root cause: the WebSocket hub tracked each player's connection as a single overwritten pointer keyed by `roomID:playerID`. If a player briefly held two open connections for the same room (duplicate tab, phone browser resuming from background, a reconnect race) and the newer one closed first, the hub wrongly treated that as the player disconnecting - even though their original connection was still open and fine.
- That started a grace-period timer (5 min multiplayer / 30 min solo). When it fired, the player was actually removed from the room and a `player_left` event broadcast, which their still-open original tab received for its own player ID - causing it to treat itself as booted and navigate home, with no visible cause.
- Fix: track connections per player with a reference count instead of a single pointer. A player is only marked disconnected once their *last* open connection closes.
- Considered evicting the older connection immediately on a new one (single-session enforcement) instead, but that would forcibly kick a player's other legitimate tab/device just for having two open, which isn't wanted here - reference counting lets multiple connections coexist peacefully.

## Test plan
- [x] `go test ./...` - all pass
- [x] New regression test `TestDuplicateConnectionUnregisterKeepsPlayerConnected`, covering both orderings (closing the first- vs. last-registered duplicate connection)
- [x] Verified via revert-and-confirm: the new test fails against the pre-fix code and passes against the fix
- [x] Live 2-tab repro against a running server with a shortened grace period: reproduced the bug against the old code (player kicked ~5s after a duplicate connection closed), then confirmed the fix keeps the player connected in the same scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)