### PR TITLE
Fix join-preview og:image URL missing the reverse-proxy path prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       # Public URL of the client, used to build the redirect target for
       # join-room preview links (the client is a separate origin/port here)
       - PUBLIC_CLIENT_URL=http://localhost
+      # This server's own public URL, used to build the og:image URL for
+      # join-room preview links. No reverse-proxy prefix to account for in
+      # this docker-compose setup, so it's just the direct port mapping -
+      # see docs/BASE_PATH_SETUP.md for the k8s case, where this needs to
+      # include the path prefix a proxy strips before forwarding here.
+      - PUBLIC_SERVER_URL=http://localhost:8080
     volumes:
       # Persist data across container restarts
       - bouncebot-data:/data

--- a/docs/BASE_PATH_SETUP.md
+++ b/docs/BASE_PATH_SETUP.md
@@ -69,8 +69,9 @@ The production deployment lives in `apps/base/bouncebot/` and uses Kustomize. Th
 The base deployment serves at the root path (`/`):
 
 - **`client.yaml`** - Client deployment with `API_BASE_URL=/api` env var, plus a ClusterIP service on port 80
-- **`server.yaml`** - Server deployment with `ALLOWED_ORIGINS`, `DATA_FILE`, `PUBLIC_CLIENT_URL` env vars, a PVC volume mount, and a ClusterIP service on port 8080
+- **`server.yaml`** - Server deployment with `ALLOWED_ORIGINS`, `DATA_FILE`, `PUBLIC_CLIENT_URL`, `PUBLIC_SERVER_URL` env vars, a PVC volume mount, and a ClusterIP service on port 8080
   - `PUBLIC_CLIENT_URL` must point at the real public client URL (e.g. `https://bouncebot.example.com`) - it's used to build the redirect target for join-room preview links (`/join/:roomId`), since the server and client don't share an origin at the container level. Left unset, join links will redirect to `http://localhost:5173`.
+  - `PUBLIC_SERVER_URL` must be this server's own full public URL, **including the `/api` prefix Traefik strips** (e.g. `https://bouncebot.example.com/api`) - it's used to build the og:image URL for join-room preview links. The server never sees `/api` on the incoming request (the `stripPrefix` middleware removes it before forwarding), so it can't be derived from the request itself the way `PUBLIC_CLIENT_URL` could in theory be - it has to be told the full external path. Left unset (or missing the prefix), the preview image 404s and chat apps show the fallback text with no image.
 - **`ingress.yaml`** - Traefik ingress routing `/api` to the server (with a `stripPrefix` middleware to remove `/api`) and `/` to the client
 - **`storage.yaml`** - PersistentVolumeClaim for server room data
 - **`namespace.yaml`** - Creates the `bouncebot` namespace
@@ -89,7 +90,7 @@ The beta overlay uses the base as a resource and applies patches to run alongsid
 
 **Client env vars**: Sets `API_BASE_URL=/beta/api` and `BASE_PATH=/beta/` on the client container
 
-**Server env vars**: Sets `PUBLIC_CLIENT_URL` to the beta client's public URL (e.g. `https://bouncebot.example.com/beta`) so beta join links redirect to the beta app, not prod
+**Server env vars**: Sets `PUBLIC_CLIENT_URL` to the beta client's public URL (e.g. `https://bouncebot.example.com/beta`) so beta join links redirect to the beta app, not prod. Also sets `PUBLIC_SERVER_URL` to the beta server's full public URL including its own stripped prefix (e.g. `https://bouncebot.example.com/beta/api`), not just `/api` - the beta overlay strips `/beta/api`, not `/api`.
 
 **Ingress patches**:
 - Routes `/beta/api` to the beta server service, `/beta` to the beta client service

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=builder /bouncebot-server /bouncebot-server
 # SOLO_DISCONNECT_GRACE_PERIOD: Solo mode disconnect grace period in seconds (default: 1800)
 # ENABLE_DAILY_CHALLENGE: Enable daily challenge feature (default: false)
 # PUBLIC_CLIENT_URL: Public base URL of the client SPA (default: http://localhost:5173)
+# PUBLIC_SERVER_URL: This server's own public base URL, including any reverse-proxy path prefix (default: http://localhost:8080)
 
 # Expose the server port
 EXPOSE 8080

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -46,6 +46,15 @@ type Config struct {
 	// for join-room preview links, since the server and client don't share
 	// an origin.
 	PublicClientURL string
+
+	// PublicServerURL is this server's own public base URL, INCLUDING any
+	// path prefix a reverse proxy strips before forwarding (e.g.
+	// "https://bouncebot.example.com/beta/api"). Used to build the og:image
+	// URL for join-room preview links. Can't be derived from the incoming
+	// request's Host header alone: a stripPrefix-style proxy removes the
+	// prefix before the server ever sees the request, so from the server's
+	// perspective that prefix doesn't exist.
+	PublicServerURL string
 }
 
 // DefaultConfig returns configuration with sensible defaults.
@@ -62,6 +71,7 @@ func DefaultConfig() *Config {
 		SoloDisconnectGracePeriod: 30 * time.Minute,
 		SolverTimeout:         30 * time.Second,
 		PublicClientURL:       "http://localhost:5173",
+		PublicServerURL:       "http://localhost:8080",
 	}
 }
 
@@ -86,6 +96,7 @@ func (c *Config) RoomsFile() string {
 //   - SOLVER_TIMEOUT: Solver timeout in seconds (default: 30)
 //   - ENABLE_DAILY_CHALLENGE: Enable daily challenge feature (default: false)
 //   - PUBLIC_CLIENT_URL: Public base URL of the client SPA (default: http://localhost:5173)
+//   - PUBLIC_SERVER_URL: This server's own public base URL, including any reverse-proxy path prefix (default: http://localhost:8080)
 func LoadFromEnv() *Config {
 	// Load .env.local (personal overrides, gitignored) then .env (checked-in defaults).
 	// Each call is separate so a missing .env.local doesn't prevent loading .env.
@@ -162,6 +173,10 @@ func LoadFromEnv() *Config {
 
 	if v := os.Getenv("PUBLIC_CLIENT_URL"); v != "" {
 		cfg.PublicClientURL = strings.TrimSuffix(v, "/")
+	}
+
+	if v := os.Getenv("PUBLIC_SERVER_URL"); v != "" {
+		cfg.PublicServerURL = strings.TrimSuffix(v, "/")
 	}
 
 	return cfg

--- a/server/join_handler.go
+++ b/server/join_handler.go
@@ -9,21 +9,6 @@ import (
 	"github.com/srsalisbury/bouncebot/server/room"
 )
 
-// requestOrigin reconstructs this server's own externally-visible origin
-// from the incoming request, so the og:image URL is absolute (required by
-// most link-preview crawlers) without needing a separate config value for
-// something the request already tells us.
-func requestOrigin(r *http.Request) string {
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
-		scheme = proto
-	}
-	return scheme + "://" + r.Host
-}
-
 const joinPageTemplate = `<!doctype html>
 <html lang="en">
 <head>
@@ -60,7 +45,7 @@ This BounceBot room doesn't exist anymore. <a href="%[1]s">Go to BounceBot</a>.
 // with real Open Graph tags, so link-preview crawlers (which don't run
 // JavaScript) see a proper preview. Real browsers land here for an instant
 // and get forwarded into the actual SPA room route.
-func handleJoinPage(rooms *room.RoomService, publicClientURL string) http.HandlerFunc {
+func handleJoinPage(rooms *room.RoomService, publicClientURL, publicServerURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		roomID := r.PathValue("roomId")
 		roomURL := fmt.Sprintf("%s/room/%s", publicClientURL, roomID)
@@ -74,7 +59,7 @@ func handleJoinPage(rooms *room.RoomService, publicClientURL string) http.Handle
 
 		title := "Join a BounceBot game!"
 		description := fmt.Sprintf("Room %s is waiting - tap to jump in.", roomID)
-		imageURL := fmt.Sprintf("%s/join/%s/preview.png", requestOrigin(r), roomID)
+		imageURL := fmt.Sprintf("%s/join/%s/preview.png", publicServerURL, roomID)
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprintf(w, joinPageTemplate,

--- a/server/join_handler_test.go
+++ b/server/join_handler_test.go
@@ -14,8 +14,13 @@ func TestHandleJoinPage_ExistingRoom(t *testing.T) {
 	svc := room.NewRoomService()
 	createdRoom, _, _ := svc.Create("Mike", false)
 
-	handler := handleJoinPage(svc, "https://client.example.com")
-	req := httptest.NewRequest("GET", "https://api.example.com/join/"+createdRoom.ID, nil)
+	// publicServerURL deliberately includes a reverse-proxy path prefix
+	// (e.g. Traefik's stripPrefix for the "/beta/api" subpath) that the
+	// server would never see on the incoming request itself, to guard
+	// against reintroducing the request-Host-based URL construction this
+	// replaced - that approach silently dropped exactly this kind of prefix.
+	handler := handleJoinPage(svc, "https://client.example.com/beta", "https://client.example.com/beta/api")
+	req := httptest.NewRequest("GET", "https://client.example.com/beta/api/join/"+createdRoom.ID, nil)
 	req.SetPathValue("roomId", createdRoom.ID)
 	rec := httptest.NewRecorder()
 
@@ -26,7 +31,7 @@ func TestHandleJoinPage_ExistingRoom(t *testing.T) {
 	}
 	body := rec.Body.String()
 
-	roomURL := "https://client.example.com/room/" + createdRoom.ID
+	roomURL := "https://client.example.com/beta/room/" + createdRoom.ID
 	if !strings.Contains(body, `content="0;url=`+roomURL+`"`) {
 		t.Errorf("expected meta-refresh redirect to %s, got body: %s", roomURL, body)
 	}
@@ -34,7 +39,7 @@ func TestHandleJoinPage_ExistingRoom(t *testing.T) {
 		t.Errorf("expected JS redirect to %s, got body: %s", roomURL, body)
 	}
 
-	imageURL := "https://api.example.com/join/" + createdRoom.ID + "/preview.png"
+	imageURL := "https://client.example.com/beta/api/join/" + createdRoom.ID + "/preview.png"
 	if !strings.Contains(body, `property="og:image" content="`+imageURL+`"`) {
 		t.Errorf("expected og:image pointing at %s, got body: %s", imageURL, body)
 	}
@@ -54,7 +59,7 @@ func TestHandleJoinPage_ExistingRoom(t *testing.T) {
 
 func TestHandleJoinPage_NonexistentRoom(t *testing.T) {
 	svc := room.NewRoomService()
-	handler := handleJoinPage(svc, "https://client.example.com")
+	handler := handleJoinPage(svc, "https://client.example.com", "https://client.example.com/api")
 
 	req := httptest.NewRequest("GET", "https://api.example.com/join/NOPE", nil)
 	req.SetPathValue("roomId", "NOPE")

--- a/server/main.go
+++ b/server/main.go
@@ -192,7 +192,7 @@ func main() {
 	// Join-room link preview: a server-rendered page with real Open Graph
 	// tags (crawlers don't run JS, so the SPA's static index.html can't
 	// carry per-room content) that forwards real browsers into the app.
-	mux.HandleFunc("GET /join/{roomId}", handleJoinPage(rooms, cfg.PublicClientURL))
+	mux.HandleFunc("GET /join/{roomId}", handleJoinPage(rooms, cfg.PublicClientURL, cfg.PublicServerURL))
 	mux.HandleFunc("GET /join/{roomId}/preview.png", handleJoinPreviewImage(rooms))
 
 	// CORS configuration for browser access


### PR DESCRIPTION
## Summary
- Bug found on the deployed beta instance (bouncebot.salisburyclan.com/beta): join links showed the fallback text preview but no image in chat apps.
- Root cause: the og:image URL was built from `r.Host` (the incoming request's Host header), which can't reflect a path prefix a reverse proxy strips before forwarding - Traefik's `stripPrefix` middleware removes `/beta/api` before the request ever reaches the Go server, so the server has no way to know that prefix exists.
- Fix: add an explicit `PUBLIC_SERVER_URL` config value (mirroring the existing `PUBLIC_CLIENT_URL`) and use it directly instead of inferring anything from the request.
- Updated `docker-compose.yml`, `server/Dockerfile`, and `docs/BASE_PATH_SETUP.md` to document the new env var and explain why it can't be auto-detected.
- **Deployment note**: `homelab-v1`'s `server.yaml` needs `PUBLIC_SERVER_URL=https://bouncebot.salisburyclan.com/beta/api` on the beta deployment (and `.../api` for prod) - outside this repo, so I couldn't set it myself.

## Test plan
- [x] `go test ./...` - all pass
- [x] Updated `TestHandleJoinPage_ExistingRoom` to specifically exercise a proxy-stripped path prefix (`/beta/api`), guarding against this exact regression
- [x] Reproduced against the pre-fix code (build fails / old code structurally can't carry a prefix) before confirming the fix
- [x] Manual: ran the server locally with `PUBLIC_CLIENT_URL`/`PUBLIC_SERVER_URL` set to match the real beta deployment and confirmed the generated og:image URL is exactly `https://bouncebot.salisburyclan.com/beta/api/join/:roomId/preview.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)