### PR TITLE
Add QR code sharing for room invite links

### DIFF
--- a/client/web/src/components/ShareModal.vue
+++ b/client/web/src/components/ShareModal.vue
@@ -2,10 +2,14 @@
 import { ref, watch } from 'vue'
 import QRCode from 'qrcode'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   show: boolean
   url: string
-}>()
+  title?: string
+  code?: string
+}>(), {
+  title: 'Share Board',
+})
 
 const emit = defineEmits<{
   close: []
@@ -57,10 +61,12 @@ async function copyLink() {
     <div v-if="show" class="modal-backdrop" @click="handleBackdropClick">
       <div class="modal share-modal">
         <button class="close-btn" @click="emit('close')">×</button>
-        <h2>Share Board</h2>
+        <h2>{{ title }}</h2>
+
+        <code v-if="code" class="code-display">{{ code }}</code>
 
         <div class="qr-wrapper">
-          <img v-if="qrDataUrl" :src="qrDataUrl" alt="QR code for the shared board link" class="qr-image" />
+          <img v-if="qrDataUrl" :src="qrDataUrl" alt="QR code for the shared link" class="qr-image" />
         </div>
 
         <button class="copy-link-btn" @click="copyLink">{{ copyLabel }}</button>
@@ -127,6 +133,18 @@ h2 {
   margin: 0 0 1.25rem 0;
   color: #43a047;
   font-size: 1.25rem;
+}
+
+.code-display {
+  display: block;
+  margin: 0 0 1.25rem 0;
+  background: #1e88e5;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: #fff;
 }
 
 .qr-wrapper {

--- a/client/web/src/views/RoomView.vue
+++ b/client/web/src/views/RoomView.vue
@@ -36,6 +36,7 @@ const showStatsDropdown = ref(false)
 const showSettings = ref(false)
 const showShareModal = ref(false)
 const shareBoardUrl = ref('')
+const showInviteModal = ref(false)
 
 // Room connection composable
 const {
@@ -277,20 +278,6 @@ async function joinRoom() {
   isJoining.value = false
 }
 
-async function copyShareUrl() {
-  try {
-    await navigator.clipboard.writeText(shareUrl.value)
-  } catch (err) {
-    // Fallback for older browsers or when clipboard API fails
-    const textArea = document.createElement('textarea')
-    textArea.value = shareUrl.value
-    document.body.appendChild(textArea)
-    textArea.select()
-    document.execCommand('copy')
-    document.body.removeChild(textArea)
-  }
-}
-
 function openShareModal() {
   if (!room.value?.currentGame) return
   try {
@@ -481,7 +468,7 @@ async function bootPlayer(targetPlayerId: string) {
 
 function globalKeyHandler(event: KeyboardEvent) {
   // Don't handle if any dialog is open
-  if (showProtectedSolutionDialog.value || showLeaveConfirm.value || showSettings.value || showShareModal.value) return
+  if (showProtectedSolutionDialog.value || showLeaveConfirm.value || showSettings.value || showShareModal.value || showInviteModal.value) return
 
   if (event.key === 'l' && (hasGame.value || gameEnded.value)) {
     event.preventDefault()
@@ -544,6 +531,23 @@ watch(showShareModal, (show) => {
     window.addEventListener('keydown', shareModalKeyHandler, true)
   } else {
     window.removeEventListener('keydown', shareModalKeyHandler, true)
+  }
+})
+
+function inviteModalKeyHandler(event: KeyboardEvent) {
+  if (!showInviteModal.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    showInviteModal.value = false
+  }
+}
+
+watch(showInviteModal, (show) => {
+  if (show) {
+    window.addEventListener('keydown', inviteModalKeyHandler, true)
+  } else {
+    window.removeEventListener('keydown', inviteModalKeyHandler, true)
   }
 })
 
@@ -735,6 +739,9 @@ onUnmounted(() => {
             <span class="label">Room ID</span>
             <code class="room-id">{{ room.id }}</code>
           </div>
+          <div class="room-actions">
+            <button class="btn-small" @click="showInviteModal = true">Invite</button>
+          </div>
         </div>
 
         <div class="players-section">
@@ -766,7 +773,7 @@ onUnmounted(() => {
             <code class="room-id">{{ room.id }}</code>
           </div>
           <div class="room-actions">
-            <button class="btn-small" @click="copyShareUrl">Copy Link</button>
+            <button class="btn-small" @click="showInviteModal = true">Invite</button>
             <button v-if="isRoomCreator" class="btn-small settings-btn" @click="showSettings = true" title="Room Settings">
               <img src="/gear.svg" alt="Settings" class="gear-icon" />
             </button>
@@ -792,7 +799,7 @@ onUnmounted(() => {
           <p v-else class="waiting-text">Waiting for room creator to start game...</p>
         </div>
 
-        <p class="hint">Share the link above with friends to play together!</p>
+        <p class="hint">Click Invite to share this room with friends!</p>
       </div>
     </div>
 
@@ -850,6 +857,15 @@ onUnmounted(() => {
       :show="showShareModal"
       :url="shareBoardUrl"
       @close="showShareModal = false"
+    />
+
+    <!-- Invite players modal -->
+    <ShareModal
+      :show="showInviteModal"
+      :url="shareUrl"
+      title="Invite Players"
+      :code="room?.id"
+      @close="showInviteModal = false"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- The waiting room's "Copy Link" button had no copy confirmation and only offered a link, not a QR code.
- Generalized `ShareModal.vue` (already built for board-sharing) with optional `title`/`code` props rather than duplicating it, and replaced "Copy Link" with a single "Invite" button that opens it - shows the room code prominently (unlike board-share codes, room IDs are short and meant to be read aloud/typed manually), a QR code, and a Copy Link button with proper "Copied!" feedback.
- Added the same "Invite" button to the pending-player view (joined mid-game, waiting for the next round), which previously had no invite affordance at all.

## Test plan
- [x] `vue-tsc --noEmit` / `vitest run` - clean, all 92 tests pass
- [x] Manual: clicked Invite in the main waiting room - correct room code, QR, and join URL (verified via clipboard read)
- [x] Manual: "Copied!" feedback and Escape-to-close both work
- [x] Manual: joined a second player mid-game to reach the pending-player view and confirmed Invite works there too
- [x] Confirmed the existing board-share modal (`title` defaults to "Share Board") is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)