### PR TITLE
Fix docker-compose: client couldn't reach the server API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
       - "80:80"
     environment:
       - BASE_PATH=${BASE_PATH:-/}
+      # nginx here has no /api proxy rule (that only exists in the separate
+      # k8s ingress), so the client must call the server directly cross-port
+      # rather than through a relative "/api" path.
+      - API_BASE_URL=http://localhost:8080
     depends_on:
       - server
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Found while testing the latest merged changes via `docker compose up`: "Play Solo" and "Create Room" both failed with HTTP 405.
- Root cause: the client service never set `API_BASE_URL`, so it defaulted to the relative path `/api`. This repo's `nginx.conf` has no proxy rule for `/api` (that only exists in the separate k8s ingress), so a POST to `/api/...` fell through nginx's static-file `try_files` fallback - nginx returns 405 for non-GET requests against a static file.
- Fix: set `API_BASE_URL=http://localhost:8080` so the browser calls the server directly cross-port instead of through a proxy path that doesn't exist in this docker-compose setup. Already CORS-enabled via `ALLOWED_ORIGINS=localhost`.

## Test plan
- [x] `docker compose build && docker compose up -d`
- [x] Confirmed `config.js` reflects the new `API_BASE_URL`
- [x] Manual: "Play Solo" now loads a full game board through the Docker deployment (previously 405'd)
- [x] Manual: cross-origin `CreateRoom` RPC call succeeds
- [x] `docker compose logs` clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)