### PR TITLE
Add live spectator view for players waiting to join next round

### DIFF
--- a/client/web/src/components/GameBoard.vue
+++ b/client/web/src/components/GameBoard.vue
@@ -27,6 +27,14 @@ const props = defineProps<{
   roomId?: string
   gameNumber?: number
   inputBlocked?: boolean
+  // For pending players watching the in-progress round they'll join next.
+  // Implies inputBlocked (a spectator can never move anything, full stop -
+  // this isn't the same as inputBlocked alone, which just *temporarily*
+  // blocks input, e.g. while a modal is open, and leaves the action buttons
+  // visible for when it's released). Also hides the action buttons and
+  // in-progress solutions panel, which show the *viewer's own* candidate
+  // solutions and don't apply to someone who isn't playing this round.
+  spectatorMode?: boolean
   singlePlayer?: boolean
   getBestSubmittedIndex?: () => number | null
   onSolutionDeleted?: (index: number) => void
@@ -207,7 +215,7 @@ useGameInput(
     onCloseHelp: () => { showHowToPlay.value = false },
   },
   {
-    inputBlocked: computed(() => props.inputBlocked ?? false),
+    inputBlocked: computed(() => !!(props.inputBlocked || props.spectatorMode)),
     gameEnded: computed(() => props.gameEnded ?? false),
     helpOpen: showHowToPlay,
     selectedRobotId: computed(() => store.selectedRobotId),
@@ -223,7 +231,7 @@ useSwipe({
   target: boardRef,
   onSwipeStart: ({ relativeX, relativeY }) => {
     swipeStartRobotId = null
-    if (props.inputBlocked || props.gameEnded) return
+    if (props.inputBlocked || props.gameEnded || props.spectatorMode) return
     // Convert normalized position to cell coordinates
     const cellX = Math.floor(relativeX * BOARD_SIZE)
     const cellY = Math.floor(relativeY * BOARD_SIZE)
@@ -234,7 +242,7 @@ useSwipe({
     }
   },
   onSwipe: (direction) => {
-    if (props.inputBlocked || props.gameEnded) return
+    if (props.inputBlocked || props.gameEnded || props.spectatorMode) return
     // If swipe started on a robot, select it (if not already selected)
     if (swipeStartRobotId !== null && store.selectedRobotId !== swipeStartRobotId) {
       store.selectRobot(swipeStartRobotId)
@@ -244,7 +252,7 @@ useSwipe({
       store.moveRobot(direction)
     }
   },
-  enabled: computed(() => !props.inputBlocked && !props.gameEnded),
+  enabled: computed(() => !props.inputBlocked && !props.gameEnded && !props.spectatorMode),
 })
 
 // When game ends, start showing solutions; when new round starts, stop replay
@@ -453,7 +461,10 @@ function handleSwitchPlayerSolution(index: number) {
         <!-- Keyboard hints under board -->
         <div class="keyboard-hints">
           <div class="desktop-hints">
-            <template v-if="props.gameEnded">
+            <template v-if="props.spectatorMode">
+              You're watching - you'll play the next game
+            </template>
+            <template v-else-if="props.gameEnded">
               <kbd>Shift+←→</kbd> switch solutions
             </template>
             <template v-else>
@@ -461,7 +472,10 @@ function handleSwitchPlayerSolution(index: number) {
             </template>
           </div>
           <div class="mobile-hints">
-            <template v-if="props.gameEnded">
+            <template v-if="props.spectatorMode">
+              You're watching - you'll play the next game
+            </template>
+            <template v-else-if="props.gameEnded">
               swipe through solutions
             </template>
             <template v-else>
@@ -487,8 +501,9 @@ function handleSwitchPlayerSolution(index: number) {
           @switch-solution="handleSwitchPlayerSolution"
         />
 
-        <!-- Normal solutions panel (during game) -->
-        <div v-else-if="!props.gameEnded" class="solutions-panel" :style="props.playerColor ? { '--player-color': props.playerColor } as any : undefined">
+        <!-- Normal solutions panel (during game) - the viewer's own candidate
+             solutions, not applicable to a spectator watching someone else's round -->
+        <div v-else-if="!props.gameEnded && !props.spectatorMode" class="solutions-panel" :style="props.playerColor ? { '--player-color': props.playerColor } as any : undefined">
           <div class="solutions-columns">
             <div
               v-for="(solution, index) in store.solutions"
@@ -556,7 +571,7 @@ function handleSwitchPlayerSolution(index: number) {
       </div>
 
       <!-- Action buttons under board (mobile) -->
-      <div v-if="!props.gameEnded" class="action-buttons mobile-actions">
+      <div v-if="!props.gameEnded && !props.spectatorMode" class="action-buttons mobile-actions">
         <button
           class="action-btn undo-btn"
           @pointerdown="onUndoPointerDown"

--- a/client/web/src/components/PlayersPanel.vue
+++ b/client/web/src/components/PlayersPanel.vue
@@ -243,7 +243,7 @@ function getSolveTime(solution: PlayerSolution): string | null {
       </div>
     </TransitionGroup>
     <!-- Timer display in compact mode (during game) - on right end -->
-    <div v-if="compact && gameStartedAt" class="timer-display">
+    <div v-if="gameStartedAt" class="timer-display">
       <img src="/timer.svg" alt="" class="timer-icon" />
       <span class="timer-value">{{ elapsedTime }}</span>
     </div>

--- a/client/web/src/views/RoomView.vue
+++ b/client/web/src/views/RoomView.vue
@@ -729,11 +729,28 @@ onUnmounted(() => {
       </GameBoard>
     </div>
 
-    <!-- Pending player waiting for next game -->
-    <div v-else-if="room && isPendingPlayer" class="waiting-room">
-      <h1 class="waiting-title">WAITING <span class="room-text">ROOM</span></h1>
+    <!-- Pending player watching the in-progress round they'll join next -->
+    <div v-else-if="room && isPendingPlayer" class="game-wrapper">
+      <GameBoard
+        spectator-mode
+        :get-player-name="getPlayerName"
+        :get-player-color="getPlayerColorById"
+        :game-started-at="room.gameStartedAt"
+        :room-id="room.id"
+        :game-number="displayedGameNumber"
+      >
+        <template #header>
+          <div class="game-header">
+            <PlayersPanel :players="room.players" :solutions="room.solutions" :scores="room.scores" :game-started-at="room.gameStartedAt" :finished-solving="room.finishedSolving" show-host hide-waiting-message />
+            <div v-if="minSolverMoves !== null" class="solver-status">
+              <img src="/favicon_dark.svg" alt="" class="solver-icon" />
+              <span class="solver-moves">{{ minSolverMoves }}</span>
+            </div>
+          </div>
+        </template>
+      </GameBoard>
 
-      <div class="card">
+      <div class="spectator-footer">
         <div class="room-info">
           <div class="info-row">
             <span class="label">Room ID</span>
@@ -744,21 +761,10 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <div class="players-section">
-          <h3>Players in game</h3>
-          <PlayersPanel :players="room.players" hide-waiting-message show-host />
-        </div>
-
-        <div class="players-section">
-          <h3>Waiting to join</h3>
+        <div v-if="room.pendingPlayers.length > 1" class="players-section">
+          <h3>Also waiting to join</h3>
           <PlayersPanel :players="room.pendingPlayers" hide-waiting-message />
         </div>
-
-        <div class="start-options">
-          <p class="waiting-text">Waiting for next game...</p>
-        </div>
-
-        <p class="hint">You'll join the game when the current round ends.</p>
       </div>
     </div>
 
@@ -949,6 +955,26 @@ onUnmounted(() => {
   padding: 1rem 0;
   min-height: 100vh;
   box-sizing: border-box;
+}
+
+.spectator-footer {
+  background: #1a1a1a;
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  width: calc(100% - 2rem);
+  max-width: 360px;
+  margin-top: 1.5rem;
+  box-sizing: border-box;
+}
+
+.spectator-footer .room-info {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.spectator-footer .players-section {
+  margin-top: 1.5rem;
 }
 
 .game-header {


### PR DESCRIPTION
## Summary
- Players who join a room mid-round used to see a bare name list and "waiting for next game" text - no visibility into the round already in progress, and nothing to do but wait.
- They now see the actual board (fully read-only) plus a live leaderboard: each player's current best move count, solve time, a finished checkmark, BBot's live move count, and an elapsed-time clock.
- Deliberately reuses the exact same components/settings gates already used for active players (`PlayersPanel`, `showSolverMoveCount`, the `minSolverMoves` computed), so a spectator never sees anything an active player couldn't already see live during their own round. The literal move sequences (the actual answer) stay hidden until the round ends, unchanged from today.
- New `spectatorMode` prop on `GameBoard`: hides the action buttons / in-progress-solutions panel (which show the *viewer's own* candidate solutions - not applicable to someone who isn't playing), and directly blocks all move/select input at the source (`useGameInput`, swipe handling, undo) rather than depending on a separately-passed `inputBlocked` prop always being set correctly by every caller.

## Test plan
- [x] `vue-tsc --noEmit` / `vitest run` - clean, all 92 tests pass
- [x] Self-reviewed the diff before commit; found and fixed two issues: (1) `spectatorMode` originally only hid UI without blocking input at the source - fixed by folding it into `useGameInput`'s `enabled` check and the swipe/undo handlers; (2) a CSS gap left a dangling divider/empty padding in the common case of only one pending player
- [x] Manual: real two-tab multiplayer session (active host + a second player joining mid-round) - board renders correctly, live leaderboard/clock update, active player's own view unaffected
- [x] Manual: confirmed via direct Pinia state inspection that arrow keys, clicking a robot, etc. produce zero state change for the spectator

🤖 Generated with [Claude Code](https://claude.com/claude-code)