### PR TITLE
Reveal spectator solutions after round ends

### DIFF
--- a/client/web/src/components/GameBoard.vue
+++ b/client/web/src/components/GameBoard.vue
@@ -191,6 +191,15 @@ function onUndoPointerCancel() {
   }
 }
 
+// Clicking a robot directly bypasses useGameInput entirely (that only
+// handles keyboard/swipe), so it needs its own guard against the same
+// conditions - otherwise a spectator (or anyone else input should be
+// blocked for, e.g. a modal open) could still select a robot by clicking it.
+function handleRobotClick(robotId: number) {
+  if (props.inputBlocked || props.spectatorMode) return
+  store.selectRobot(robotId)
+}
+
 // Input handling composable
 useGameInput(
   {
@@ -215,8 +224,9 @@ useGameInput(
     onCloseHelp: () => { showHowToPlay.value = false },
   },
   {
-    inputBlocked: computed(() => !!(props.inputBlocked || props.spectatorMode)),
+    inputBlocked: computed(() => props.inputBlocked ?? false),
     gameEnded: computed(() => props.gameEnded ?? false),
+    spectatorMode: computed(() => props.spectatorMode ?? false),
     helpOpen: showHowToPlay,
     selectedRobotId: computed(() => store.selectedRobotId),
     robotCount: computed(() => store.robots.length),
@@ -374,6 +384,7 @@ function handleSwitchPlayerSolution(index: number) {
       <!-- Board layout (grid: title on top, board and solutions below) -->
       <div class="board-layout">
         <h1 v-if="props.gameNumber != null" class="title">
+          <span v-if="props.spectatorMode" class="watching-label">WATCHING</span>
           <span class="game-label">GAME</span>
           <span class="game-number">{{ props.gameNumber }}</span>
           <button class="share-btn" title="Share this board" aria-label="Share this board" @click="emit('share')">
@@ -430,7 +441,7 @@ function handleSwitchPlayerSolution(index: number) {
               class="robot"
               :class="{ selected: store.selectedRobotId === robot.id, replaying: isReplaying }"
               :style="getRobotStyle(robot)"
-              @click="store.selectRobot(robot.id)"
+              @click="handleRobotClick(robot.id)"
             >
               {{ robot.id + 1 }}
             </div>
@@ -461,22 +472,22 @@ function handleSwitchPlayerSolution(index: number) {
         <!-- Keyboard hints under board -->
         <div class="keyboard-hints">
           <div class="desktop-hints">
-            <template v-if="props.spectatorMode">
-              You're watching - you'll play the next game
-            </template>
-            <template v-else-if="props.gameEnded">
+            <template v-if="props.gameEnded">
               <kbd>Shift+←→</kbd> switch solutions
+            </template>
+            <template v-else-if="props.spectatorMode">
+              You're watching - you'll play the next game
             </template>
             <template v-else>
               <kbd>1-4</kbd> select · <kbd>↑↓←→</kbd> move · <kbd>z</kbd> undo · <kbd>?</kbd> help
             </template>
           </div>
           <div class="mobile-hints">
-            <template v-if="props.spectatorMode">
-              You're watching - you'll play the next game
-            </template>
-            <template v-else-if="props.gameEnded">
+            <template v-if="props.gameEnded">
               swipe through solutions
+            </template>
+            <template v-else-if="props.spectatorMode">
+              You're watching - you'll play the next game
             </template>
             <template v-else>
               tap to select · swipe to move
@@ -592,9 +603,10 @@ function handleSwitchPlayerSolution(index: number) {
       </div>
     </div>
 
-    <!-- Mobile solutions drawer (only during gameplay, hidden on desktop) -->
+    <!-- Mobile solutions drawer (only during gameplay, hidden on desktop) -
+         the viewer's own candidate solutions, not applicable to a spectator -->
     <SolutionsDrawer
-      v-if="!props.gameEnded"
+      v-if="!props.gameEnded && !props.spectatorMode"
       class="mobile-drawer"
       :player-color="props.playerColor"
       :get-best-submitted-index="props.getBestSubmittedIndex"
@@ -699,6 +711,14 @@ function handleSwitchPlayerSolution(index: number) {
 
 .share-btn:hover {
   background: #1565c0;
+}
+
+.watching-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: #888;
 }
 
 .game-label {

--- a/client/web/src/components/PlayersPanel.vue
+++ b/client/web/src/components/PlayersPanel.vue
@@ -243,7 +243,7 @@ function getSolveTime(solution: PlayerSolution): string | null {
       </div>
     </TransitionGroup>
     <!-- Timer display in compact mode (during game) - on right end -->
-    <div v-if="gameStartedAt" class="timer-display">
+    <div v-if="compact && gameStartedAt" class="timer-display">
       <img src="/timer.svg" alt="" class="timer-icon" />
       <span class="timer-value">{{ elapsedTime }}</span>
     </div>

--- a/client/web/src/composables/useGameInput.test.ts
+++ b/client/web/src/composables/useGameInput.test.ts
@@ -240,4 +240,48 @@ describe('useGameInput', () => {
       expect(callbacks.onToggleHelp).toHaveBeenCalled()
     })
   })
+
+  describe('spectator mode', () => {
+    it('blocks movement, selection, undo, and new solution while the round is still in progress', () => {
+      const callbacks = createMockCallbacks()
+      const { handleKeydown } = useGameInput(callbacks, createOptions({
+        spectatorMode: ref(true),
+      }))
+
+      handleKeydown(keyEvent('ArrowUp'))
+      handleKeydown(keyEvent('1'))
+      handleKeydown(keyEvent('z'))
+      handleKeydown(keyEvent('n'))
+
+      expect(callbacks.onMove).not.toHaveBeenCalled()
+      expect(callbacks.onSelectRobot).not.toHaveBeenCalled()
+      expect(callbacks.onUndo).not.toHaveBeenCalled()
+      expect(callbacks.onNewSolution).not.toHaveBeenCalled()
+    })
+
+    it('still allows help toggle while spectating', () => {
+      const callbacks = createMockCallbacks()
+      const { handleKeydown } = useGameInput(callbacks, createOptions({
+        spectatorMode: ref(true),
+      }))
+
+      handleKeydown(keyEvent('?'))
+      expect(callbacks.onToggleHelp).toHaveBeenCalled()
+    })
+
+    it('allows switching revealed solutions once the round has ended, unlike mid-round', () => {
+      const callbacks = createMockCallbacks()
+      const { handleKeydown } = useGameInput(callbacks, createOptions({
+        spectatorMode: ref(true),
+        gameEnded: ref(true),
+      }))
+
+      handleKeydown(keyEvent('ArrowLeft', { shiftKey: true }))
+      expect(callbacks.onSwitchPlayerSolution).toHaveBeenCalledWith(-1)
+
+      // But still never allows moving anything
+      handleKeydown(keyEvent('ArrowUp'))
+      expect(callbacks.onMove).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/client/web/src/composables/useGameInput.ts
+++ b/client/web/src/composables/useGameInput.ts
@@ -30,6 +30,13 @@ export interface GameInputCallbacks {
 export interface GameInputOptions {
   inputBlocked: Ref<boolean>
   gameEnded: Ref<boolean>
+  // A spectator watching someone else's in-progress round. Unlike
+  // inputBlocked (which blocks everything, e.g. while a modal is open), this
+  // only blocks the *movement* half of input (select/move/undo/new
+  // solution) - once gameEnded is also true, a spectator can still browse
+  // the revealed solutions the same way an active player can, since there's
+  // nothing left to protect once the round is over.
+  spectatorMode?: Ref<boolean>
   helpOpen: Ref<boolean>
   selectedRobotId: Ref<number | null>
   robotCount: Ref<number>
@@ -39,6 +46,7 @@ export function useGameInput(callbacks: GameInputCallbacks, options: GameInputOp
   const {
     inputBlocked,
     gameEnded,
+    spectatorMode,
     helpOpen,
     selectedRobotId,
     robotCount,
@@ -84,6 +92,13 @@ export function useGameInput(callbacks: GameInputCallbacks, options: GameInputOp
         return
       }
       return // Ignore other keys in game-ended mode
+    }
+
+    // Spectator watching an in-progress round: never allow moving/selecting/
+    // undoing/starting a solution - there's nothing to browse yet either
+    // (that only exists once gameEnded, handled above), so just block.
+    if (spectatorMode?.value) {
+      return
     }
 
     // Normal game mode below

--- a/client/web/src/views/RoomView.vue
+++ b/client/web/src/views/RoomView.vue
@@ -744,6 +744,7 @@ onUnmounted(() => {
         :game-started-at="room.gameStartedAt"
         :room-id="room.id"
         :game-number="displayedGameNumber"
+        @share="openShareModal"
       >
         <template #header>
           <div class="game-header">

--- a/client/web/src/views/RoomView.vue
+++ b/client/web/src/views/RoomView.vue
@@ -733,6 +733,12 @@ onUnmounted(() => {
     <div v-else-if="room && isPendingPlayer" class="game-wrapper">
       <GameBoard
         spectator-mode
+        :game-ended="gameEnded"
+        :player-solutions="sortedSolutions"
+        :current-player-solution="currentPlayerSolution"
+        :top-three-solutions="topThreeSolutions"
+        :solver-solutions="solverPlayerSolutions"
+        :is-solver-solution="isSolverSolution"
         :get-player-name="getPlayerName"
         :get-player-color="getPlayerColorById"
         :game-started-at="room.gameStartedAt"
@@ -741,7 +747,7 @@ onUnmounted(() => {
       >
         <template #header>
           <div class="game-header">
-            <PlayersPanel :players="room.players" :solutions="room.solutions" :scores="room.scores" :game-started-at="room.gameStartedAt" :finished-solving="room.finishedSolving" show-host hide-waiting-message />
+            <PlayersPanel :players="room.players" :solutions="room.solutions" :scores="room.scores" :game-started-at="room.gameStartedAt" :finished-solving="room.finishedSolving" compact />
             <div v-if="minSolverMoves !== null" class="solver-status">
               <img src="/favicon_dark.svg" alt="" class="solver-icon" />
               <span class="solver-moves">{{ minSolverMoves }}</span>


### PR DESCRIPTION
## Summary
- Phase B of the waiting-room spectator feature: once a round ends, spectators can now browse all players' revealed solution paths, reusing the existing `GameBoard`/solutions UI shown to active players (gated by the same `gameEnded` boundary already used for regular players).
- Restructured `useGameInput` so `spectatorMode` blocks movement/selection/undo/new-solution during an in-progress round, but still allows solution-switching once `gameEnded` is true.
- Fixes three issues found during manual live testing:
  - Clicking a robot directly bypassed all input guards (not gated at all, including pre-existing `inputBlocked`) — added a `handleRobotClick` guard.
  - Spectator header rendered as two awkward rows — switched `PlayersPanel` to the existing `compact` mode used by the live in-game header.
  - No indication the player was spectating rather than playing — added a "WATCHING" label above the game title.

## Test plan
- [x] `npx vitest run src/composables/useGameInput.test.ts` — 22/22 pass (3 new spectator-mode tests)
- [x] Manually verified live via two browser tabs in the same room: single-row header matches live style, "WATCHING / GAME N" title renders correctly, clicking a robot as a spectator no longer selects it (confirmed via before/after screenshots — selection ring unchanged), solutions become browsable after the round ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)