### PR TITLE
Fix spectator onboarding/highlight bugs and a room state race condition

### DIFF
--- a/client/web/src/components/GameBoard.vue
+++ b/client/web/src/components/GameBoard.vue
@@ -439,7 +439,7 @@ function handleSwitchPlayerSolution(index: number) {
               v-for="robot in store.robots"
               :key="`robot-${robot.id}`"
               class="robot"
-              :class="{ selected: store.selectedRobotId === robot.id, replaying: isReplaying }"
+              :class="{ selected: !props.spectatorMode && store.selectedRobotId === robot.id, replaying: isReplaying }"
               :style="getRobotStyle(robot)"
               @click="handleRobotClick(robot.id)"
             >
@@ -636,8 +636,9 @@ function handleSwitchPlayerSolution(index: number) {
     <!-- How to Play modal -->
     <HowToPlayModal :show="showHowToPlay" @close="showHowToPlay = false" />
 
-    <!-- First game onboarding overlay -->
-    <FirstGameOverlay :show="isFirstGame" @dismiss="dismissOnboarding" />
+    <!-- First game onboarding overlay - not shown to spectators, who can't
+         act on it yet; they'll see it once actually promoted into a game -->
+    <FirstGameOverlay :show="isFirstGame && !props.spectatorMode" @dismiss="dismissOnboarding" />
   </div>
 </template>
 

--- a/client/web/src/composables/useRoomConnection.test.ts
+++ b/client/web/src/composables/useRoomConnection.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { useRoomConnection } from './useRoomConnection'
+import { bounceBotClient } from '../services/connectClient'
+import type { Room } from '../gen/bouncebot_pb'
+
+vi.mock('../services/connectClient', () => ({
+  bounceBotClient: {
+    getRoom: vi.fn(),
+  },
+}))
+
+// Avoids pulling in the real Pinia store, which reads localStorage at setup
+// time (not available/functional in this test environment) - this test is
+// only exercising loadRoom's response-ordering guard, not room store state.
+vi.mock('../stores/roomStore', () => ({
+  useRoomStore: () => ({
+    currentPlayerId: null,
+    currentSessionToken: null,
+    lastRoomId: null,
+    setLastRoom: vi.fn(),
+    clearRoom: vi.fn(),
+  }),
+}))
+
+function fakeRoom(overrides: Partial<Room>): Room {
+  return {
+    id: 'ABCD',
+    players: [],
+    pendingPlayers: [],
+    solutions: [],
+    scores: [],
+    finishedSolving: [],
+    readyForNext: [],
+    solverResults: [],
+    gamesPlayed: 0,
+    currentGame: undefined,
+    ...overrides,
+  } as unknown as Room
+}
+
+describe('useRoomConnection', () => {
+  beforeEach(() => {
+    vi.mocked(bounceBotClient.getRoom).mockReset()
+  })
+
+  it('discards a loadRoom response that resolves after a newer one was already applied', async () => {
+    // Simulates two events firing in quick succession (e.g. "ready for next"
+    // followed shortly by "game started"), each triggering their own
+    // loadRoom call, where the network resolves them out of order.
+    const resolvers: Array<(room: Room) => void> = []
+    vi.mocked(bounceBotClient.getRoom).mockImplementation(
+      () => new Promise((resolve) => { resolvers.push(resolve as (room: Room) => void) })
+    )
+
+    const { room, loadRoom } = useRoomConnection({ roomId: ref('ABCD') })
+
+    const staleCall = loadRoom() // issued first (e.g. from "ready for next")
+    const freshCall = loadRoom(true) // issued shortly after (e.g. from "game started")
+
+    // The second (fresher) call's response arrives first.
+    resolvers[1](fakeRoom({ players: [{ id: 'p1' } as never], pendingPlayers: [] }))
+    await freshCall
+    expect(room.value?.pendingPlayers).toEqual([])
+
+    // The first (now-stale) call's response arrives late - it must not
+    // overwrite the fresher state already applied above.
+    resolvers[0](fakeRoom({ players: [], pendingPlayers: [{ id: 'p1' } as never] }))
+    await staleCall
+    expect(room.value?.pendingPlayers).toEqual([])
+  })
+
+  it('still applies responses that resolve in issue order', async () => {
+    const rooms = [
+      fakeRoom({ gamesPlayed: 0 }),
+      fakeRoom({ gamesPlayed: 1 }),
+    ]
+    vi.mocked(bounceBotClient.getRoom)
+      .mockResolvedValueOnce(rooms[0])
+      .mockResolvedValueOnce(rooms[1])
+
+    const { room, loadRoom } = useRoomConnection({ roomId: ref('ABCD') })
+
+    await loadRoom()
+    expect(room.value?.gamesPlayed).toBe(0)
+
+    await loadRoom()
+    expect(room.value?.gamesPlayed).toBe(1)
+  })
+})

--- a/client/web/src/composables/useRoomConnection.ts
+++ b/client/web/src/composables/useRoomConnection.ts
@@ -37,9 +37,21 @@ export function useRoomConnection(options: RoomConnectionOptions) {
   const hasGame = computed(() => room.value?.currentGame != null)
   const hasJoined = computed(() => roomStore.currentPlayerId != null && roomStore.currentSessionToken != null)
 
+  // Guards against out-of-order responses: two events fired in quick
+  // succession (e.g. a player's own "ready for next" broadcast, followed
+  // shortly by "game started" once board generation finishes) each trigger a
+  // loadRoom call, and the network makes no guarantee they resolve in the
+  // order they were issued. Without this, a slow response to the earlier
+  // call can land after the later one and silently overwrite fresher state
+  // with stale data (e.g. reverting a promoted pending player back to
+  // "watching" the game that just ended).
+  let loadRoomSeq = 0
+
   async function loadRoom(forceApplyGame = false) {
+    const seq = ++loadRoomSeq
     try {
       const rm = await bounceBotClient.getRoom({ roomId: normalizedRoomId.value })
+      if (seq !== loadRoomSeq) return // superseded by a newer loadRoom call
       const hadGame = hasGame.value
       room.value = rm
 
@@ -89,13 +101,16 @@ export function useRoomConnection(options: RoomConnectionOptions) {
 
       error.value = null
     } catch (e) {
+      if (seq !== loadRoomSeq) return // superseded by a newer loadRoom call
       error.value = e instanceof Error ? e.message : 'Failed to load room'
       // If server says room doesn't exist, clear stored room state (preserve player name)
       if (isRoomNotFoundError(e)) {
         roomStore.clearRoom()
       }
     } finally {
-      isLoading.value = false
+      if (seq === loadRoomSeq) {
+        isLoading.value = false
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Spectators no longer see the first-time "Welcome to BounceBot!" onboarding modal or the target-robot selection ring - neither is actionable for someone who can't move anything yet.
- Fixes a room-state race condition in `useRoomConnection.ts`'s `loadRoom()`: it had no protection against out-of-order network responses. When the last player readies up, the server broadcasts `player_ready_for_next` immediately, then broadcasts `game_started` only after board generation completes (a real gap, not instantaneous). Each broadcast triggers its own `loadRoom()` call, and if the earlier-triggered call's response happens to resolve *after* the later one, it silently overwrites the correct state with stale data - e.g. reverting a just-promoted spectator back to "watching" the game that already ended, with no further event to self-correct. This manifested as a spectator appearing stuck on the previous game after the next one started, inconsistently depending on network timing.
- Fixed with a response-sequencing guard: a `loadRoom()` response is only applied if no newer `loadRoom()` call has been issued since.

## Test plan
- [x] New test in `useRoomConnection.test.ts` deterministically simulates two overlapping `loadRoom()` calls resolving out of order; confirmed it fails on the pre-fix code and passes with the fix.
- [x] Full suite: `npx vitest run` - 97/97 pass. `npx vue-tsc --noEmit` - clean.
- [x] Manually verified live with three browser tabs (host + player + spectator joining mid-round): no onboarding modal or highlight ring for the spectator; spectator correctly promoted to an active player once the next game started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)