### PR TITLE
Remove spectator footer box, fix same-second solve sort ordering

### DIFF
--- a/client/web/src/components/PlayersPanel.vue
+++ b/client/web/src/components/PlayersPanel.vue
@@ -4,7 +4,7 @@ import type { Player, PlayerSolution, PlayerScore } from '../gen/bouncebot_pb'
 import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import { useRoomStore } from '../stores/roomStore'
 import { getPlayerColor, MAX_GAME_TIMER_SECONDS } from '../constants'
-import { getFormattedTimes, calculateDurationSeconds } from '../services/timeUtils'
+import { getFormattedTimes, calculateDurationSeconds, timestampToSeconds } from '../services/timeUtils'
 
 const props = defineProps<{
   players: Player[]
@@ -102,9 +102,7 @@ const sortedPlayers = computed(() => {
         return solA.moves.length - solB.moves.length
       }
       // Same move count: sort by solved time (earlier first)
-      const timeA = solA.solvedAt?.seconds ?? 0
-      const timeB = solB.solvedAt?.seconds ?? 0
-      return Number(timeA) - Number(timeB)
+      return timestampToSeconds(solA.solvedAt) - timestampToSeconds(solB.solvedAt)
     }
     // Only A solved: A comes first
     if (solA) return -1
@@ -125,9 +123,7 @@ const leaderPlayerId = computed(() => {
   // Find earliest among best solutions
   let earliest = bestSolutions[0]
   for (const sol of bestSolutions) {
-    const solTime = sol.solvedAt?.seconds ?? 0
-    const earliestTime = earliest?.solvedAt?.seconds ?? 0
-    if (Number(solTime) < Number(earliestTime)) {
+    if (timestampToSeconds(sol.solvedAt) < timestampToSeconds(earliest?.solvedAt)) {
       earliest = sol
     }
   }

--- a/client/web/src/services/timeUtils.test.ts
+++ b/client/web/src/services/timeUtils.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration, getFormattedTimes } from './timeUtils'
+import { formatDuration, getFormattedTimes, timestampToSeconds } from './timeUtils'
 
 describe('timeUtils', () => {
+  describe('timestampToSeconds', () => {
+    it('returns 0 for an undefined timestamp', () => {
+      expect(timestampToSeconds(undefined)).toBe(0)
+    })
+
+    it('includes sub-second precision from nanos', () => {
+      // Two solves one second apart but only 100ms into their respective
+      // seconds must not compare equal - dropping nanos would make them tie.
+      const earlier = { seconds: 10n, nanos: 100_000_000 }
+      const later = { seconds: 10n, nanos: 900_000_000 }
+      expect(timestampToSeconds(earlier)).toBeLessThan(timestampToSeconds(later))
+    })
+
+    it('distinguishes two solves within the same second', () => {
+      const a = { seconds: 5n, nanos: 200_000_000 }
+      const b = { seconds: 5n, nanos: 800_000_000 }
+      expect(timestampToSeconds(a)).not.toBe(timestampToSeconds(b))
+    })
+  })
+
   describe('formatDuration', () => {
     it('formats m:ss correctly (precision 0)', () => {
       expect(formatDuration(65.12, 0)).toBe('1:05')

--- a/client/web/src/services/timeUtils.ts
+++ b/client/web/src/services/timeUtils.ts
@@ -37,6 +37,17 @@ export function calculateDurationSeconds(start: Timestamp, end: Timestamp): numb
 }
 
 /**
+ * Converts a timestamp to a single comparable number of seconds, including
+ * sub-second precision from nanos - comparing `.seconds` alone treats any two
+ * solves within the same second as simultaneous, which silently falls back
+ * to array order instead of actual solve order.
+ */
+export function timestampToSeconds(t: Timestamp | undefined): number {
+  if (!t) return 0
+  return Number(t.seconds) + Number(t.nanos) / 1e9
+}
+
+/**
  * Generates a map of formatted time strings for a list of items.
  * Automatically increases precision (up to 2 decimal places) for items that would
  * otherwise have identical formatted strings.

--- a/client/web/src/views/RoomView.vue
+++ b/client/web/src/views/RoomView.vue
@@ -16,6 +16,7 @@ import { create } from '@bufbuild/protobuf'
 import { PlayerSolutionSchema, BotPosSchema, PositionSchema } from '../gen/bouncebot_pb'
 import { encodeShareCode } from '../shareCode'
 import { config } from '../config'
+import { timestampToSeconds } from '../services/timeUtils'
 
 const props = defineProps<{
   roomId: string
@@ -136,9 +137,7 @@ const sortedSolutions = computed(() => {
     if (a.moves.length !== b.moves.length) {
       return a.moves.length - b.moves.length
     }
-    const timeA = a.solvedAt?.seconds ?? 0n
-    const timeB = b.solvedAt?.seconds ?? 0n
-    return Number(timeA - timeB)
+    return timestampToSeconds(a.solvedAt) - timestampToSeconds(b.solvedAt)
   })
 })
 
@@ -756,23 +755,6 @@ onUnmounted(() => {
           </div>
         </template>
       </GameBoard>
-
-      <div class="spectator-footer">
-        <div class="room-info">
-          <div class="info-row">
-            <span class="label">Room ID</span>
-            <code class="room-id">{{ room.id }}</code>
-          </div>
-          <div class="room-actions">
-            <button class="btn-small" @click="showInviteModal = true">Invite</button>
-          </div>
-        </div>
-
-        <div v-if="room.pendingPlayers.length > 1" class="players-section">
-          <h3>Also waiting to join</h3>
-          <PlayersPanel :players="room.pendingPlayers" hide-waiting-message />
-        </div>
-      </div>
     </div>
 
     <!-- Waiting room -->
@@ -962,26 +944,6 @@ onUnmounted(() => {
   padding: 1rem 0;
   min-height: 100vh;
   box-sizing: border-box;
-}
-
-.spectator-footer {
-  background: #1a1a1a;
-  border-radius: 12px;
-  padding: 1.5rem 2rem;
-  width: calc(100% - 2rem);
-  max-width: 360px;
-  margin-top: 1.5rem;
-  box-sizing: border-box;
-}
-
-.spectator-footer .room-info {
-  margin-bottom: 0;
-  padding-bottom: 0;
-  border-bottom: none;
-}
-
-.spectator-footer .players-section {
-  margin-top: 1.5rem;
 }
 
 .game-header {


### PR DESCRIPTION
## Summary
- Removes the spectator footer (Room ID/Invite box, "also waiting to join" list) from the watching-mode view entirely. It duplicated info shown elsewhere, wasn't part of the live player's own game view this feature is meant to mirror, and gets obscured on mobile by the fixed-position solutions drawer once a round ends - deleting it is simpler than fighting z-index.
- Fixes player-result/leaderboard sorting: `RoomView.vue`'s `sortedSolutions` and two spots in `PlayersPanel.vue` (the live sort order and the "leader" calculation) compared `solvedAt?.seconds` directly, dropping the sub-second `nanos` field. Two solves in the same wall-clock second compared equal and fell back to array order (received order) instead of true solve order - `PlayersPanel`'s leader calc had the same bug, which could pick the wrong live leader on a same-second tie.
- Extracted a shared `timestampToSeconds()` helper in `timeUtils.ts` (mirrors the seconds+nanos pattern already used by `calculateDurationSeconds`) and applied it at all three sites.

## Test plan
- [x] New tests for `timestampToSeconds` covering the same-second-tie case.
- [x] Full suite: `npx vitest run` - 100/100 pass. `npx vue-tsc --noEmit` - clean.
- [x] Manually verified live in an actual mobile-aspect-ratio viewport: `.spectator-footer` no longer exists in the DOM before or after a round ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)