### PR TITLE
Stop caching unhashed public/ assets as immutable for a year

### DIFF
--- a/client/web/nginx.conf
+++ b/client/web/nginx.conf
@@ -15,10 +15,22 @@ server {
         add_header Expires "0";
     }
 
-    # Cache hashed static assets aggressively (Vite adds content hashes to filenames)
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+    # Cache Vite's hashed build output aggressively - its filename changes whenever the
+    # content does, so a stale cache can never serve outdated content. ^~ takes priority
+    # over the regex location below regardless of file order, so this always wins for
+    # anything under /assets/.
+    location ^~ /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+    }
+
+    # Everything else static (logos, icons, fonts, help pages, ...) is served straight from
+    # public/ with a stable filename - it can change on any deploy without a hash bump, so
+    # give it a short cache instead of a year-long one, or an edited file stays stuck behind
+    # browser/CDN caches until someone remembers to purge them by hand.
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+        expires 5m;
+        add_header Cache-Control "public, must-revalidate";
     }
 
     # Handle SPA routing - serve index.html for all routes


### PR DESCRIPTION
## Summary
- `nginx.conf` cached any `.svg/.js/.css/.png/...` file for 1 year with `immutable`, on the assumption Vite content-hashes all static assets. That's only true for the built bundle under `dist/assets/` - files copied verbatim from `public/` (logos, icons, fonts, help pages) keep a stable filename across edits, so a changed file got stuck behind browser and CDN caches for up to a year with no automatic way to bust it.
- This is exactly what just happened after updating the QR-code halo logo: Cloudflare's edge served the old file for hours, and even after purging the edge cache, browsers that had already loaded the page kept serving their own immutable-cached copy through a hard reload.
- Scoped the aggressive 1-year immutable caching to `/assets/` (Vite's actual hashed output) via a `^~` prefix location, which always wins over the extension-based regex location regardless of file order. Everything else matching the same extensions now gets a 5-minute cache instead.

## Test plan
- [x] `nginx -t` config syntax check (via `docker run nginx:alpine`)
- [x] Built the actual client Docker image and curled it directly:
  - `/assets/index-*.js` → `Cache-Control: public, immutable`, `max-age=31536000`
  - `/logo_color_halo.svg` (unhashed public/ file) → `Cache-Control: public, must-revalidate`, `max-age=300`
  - `/config.js`, `/index.html` → unchanged, still `no-cache, no-store, must-revalidate`

## Note for after merge
This doesn't retroactively fix already-cached copies - Cloudflare's edge cache for `/beta/*` and `/prod/*` (if live) should be purged once after this deploys, same as we just did manually for the halo SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)